### PR TITLE
update tld_regexpr.py

### DIFF
--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -45,6 +45,7 @@ pl = {
     'extend': 'uk',
 
     'creation_date':			r'\ncreated:\s*(.+)\n',
+    'expiration_date':          r'Renewal date:|Expiration Date:\s*(.+)',
     'updated_date':				r'\nlast modified:\s*(.+)\n',
 
     'name_servers':				r'\nnameservers:\s*(.+)\n\s*(.+)\n',


### PR DESCRIPTION
update tld_regexpr.py to support expiration date for .pl domains that use "Expiration date" line instead of "Renewal date"