### PR TITLE
Fix info domain parsing

### DIFF
--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -140,13 +140,7 @@ biz = {
 }
 
 info = {
-    'extend': 'biz',
-
-    'creation_date':			r'Created On:\s?(.+)',
-    'expiration_date':			r'Expiration Date:\s?(.+)$',
-    'updated_date':				r'Last Updated On:\s?(.+)$',
-
-    'status':					r'Status:\s?(.+)',
+    'extend': 'com'
 }
 
 name = {


### PR DESCRIPTION
## What's the change ?

Fix info domain regexes.

## Example

doing 

```python
whois.query('info.info').__dict__
```

on master : 

```python
{'name': 'info.info',
 'registrar': '',
 'creation_date': None,
 'expiration_date': None,
 'last_updated': None,
 'name_servers': {'ns1.ams1.afilias-nst.info',
  'ns1.hkg1.afilias-nst.info',
  'ns1.mia1.afilias-nst.info',
  'ns1.sea1.afilias-nst.info',
  'ns1.yyz1.afilias-nst.info'}}
```

With this PR: 

```python
{'name': 'info.info',
 'registrar': 'Afilias',
 'creation_date': datetime.datetime(2001, 10, 8, 16, 33, 16),
 'expiration_date': datetime.datetime(2018, 10, 8, 16, 33, 16),
 'last_updated': None,
 'name_servers': {'ns1.ams1.afilias-nst.info',
  'ns1.hkg1.afilias-nst.info',
  'ns1.mia1.afilias-nst.info',
  'ns1.sea1.afilias-nst.info',
  'ns1.yyz1.afilias-nst.info'}}
```