### PR TITLE
Issue #79: Fix expiration date for domain .co.uk

### DIFF
--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -33,7 +33,9 @@ uk = {
     'registrant':				r'Registrant:\n\s*(.+)',
 
     'creation_date':			r'Registered on:\s*(.+)',
-    'expiration_date':			r'Renewal date:\s*(.+)',
+    
+    'expiration_date':			r'Expiry date:\s*(.+)',
+
     'updated_date':				r'Last updated:\s*(.+)',
 
     'name_servers':				r'Name Servers:\s*(.+)\s*',


### PR DESCRIPTION
Quick fix for the Issue #79 

Whois query for domains ".co.uk" with this fix:
![image](https://user-images.githubusercontent.com/21252530/71785282-87731c00-2fdc-11ea-9ce1-cd46fea47dbb.png)

DNS query without fix (issue reported): 
![image](https://user-images.githubusercontent.com/21252530/71785296-a7a2db00-2fdc-11ea-813a-9d23695328da.png)
