### PR TITLE
Add .is - issue #16

### DIFF
--- a/test.py
+++ b/test.py
@@ -76,6 +76,7 @@ DOMAINS = '''
     google.online
     google.wiki
     google.press
+    google.is
 '''
 
 failure = list()

--- a/whois/_3_adjust.py
+++ b/whois/_3_adjust.py
@@ -81,6 +81,7 @@ DATE_FORMATS = [
     '%a %d %B %Y',                  # Tue 21 June 2011
     '%A %d %B %Y',                  # Tuesday 21 June 2011
     '%Y-%m-%d %H:%M:%S (%Z+0:00)',  # 2007-12-24 10:24:32 (gmt+0:00)
+    '%B %d %Y',                     # January 01 2000
 ]
 
 

--- a/whois/__init__.py
+++ b/whois/__init__.py
@@ -46,6 +46,8 @@ def query(domain, force=0, cache_file=None, slow_down=0, ignore_returncode=0):
 
     if domain.endswith('.co.jp'):
         tld = 'co_jp'
+    elif domain.endswith('.is'):
+        tld = 'is_is'
     elif domain.endswith('.xn--p1ai'):
         tld = 'ru_rf'
     elif domain.endswith('.ac.uk') and len(d) > 2:

--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -567,3 +567,15 @@ education = {
 ninja = {
     'extend': 'education'
 }
+
+is_is = {
+    'domain_name':                         r'domain:\s?(.+)',
+    'registrar':                           None,
+    'registrant':                          r'registrant:\s?(.+)',
+    'creation_date':                       r'created:\s?(.+)',
+    'expiration_date':                     r'expires:\s?(.+)',
+    'updated_date':                        None,
+    'name_servers':                        r'nserver:\s?(.+)',
+    'status':                              None,
+    'emails':                              r'[\w.-]+@[\w.-]+\.[\w]{2,4}',
+}


### PR DESCRIPTION
This is directly from the patch in https://github.com/DannyCork/python-whois/issues/16

>>> import whois
>>> print(whois.query('google.is').__dict__)
{'name': 'google.is', 'registrar': '', 'creation_date': datetime.datetime(2002, 5, 22, 0, 0), 'expiration_date': datetime.datetime(2020, 5, 22, 0, 0), 'last_updated': None, 'status': '', 'name_servers': {'ns2.google.com', 'ns1.google.com'}}

I'm only looking at the status + name_servers, and so haven't looked at the other attributes