### PR TITLE
Add IR ccTLD

### DIFF
--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -567,3 +567,17 @@ education = {
 ninja = {
     'extend': 'education'
 }
+
+ir = {
+    'extend': None,
+    'registrar': 'nic.ir',
+    'creation_date': None,
+    'status': None,
+
+    'domain_name':                      r'domain:\s?(.+)',
+
+    'expiration_date':                  r'expire-date:\s?(.+)',
+    'updated_date':                     r'last-updated:\s?(.+)',
+
+    'name_servers':                     r'nserver:\s*(.+)\s*',
+}


### PR DESCRIPTION
This patch adds support for ir ccTLD.
Unfortunately this TLD does not provide "domain creation date" nor "domain status", so I set them to None.