### PR TITLE
Added support for .SE, .NU and .FI TLDs

### DIFF
--- a/test.py
+++ b/test.py
@@ -76,6 +76,9 @@ DOMAINS = '''
     google.online
     google.wiki
     google.press
+    google.se
+    google.nu
+    google.fi
 '''
 
 failure = list()

--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -581,3 +581,29 @@ ir = {
 
     'name_servers':                     r'nserver:\s*(.+)\s*',
 }
+
+se = {
+    'extend': None,
+    'domain_name':              r'domain:\s?(.+)',
+    'registrar':                r'registrar:\s?(.+)',
+    'creation_date':            r'created:\s?(.+)',
+    'expiration_date':          r'expires:\s?(.+)',
+    'updated_date':             r'modified:\s?(.+)',
+    'name_servers':             r'nserver:\s*(.+)',
+    'status':                   r'status:\s?(.+)',
+}
+
+nu = {
+    'extend': 'se'
+}
+
+fi = {
+    'extend': None,
+    'domain_name':              r'domain\.+:\s?(.+)',
+    'registrar':                r'registrar\.+:\s?(.+)',
+    'creation_date':            r'created\.+:\s?(.+)',
+    'expiration_date':          r'expires\.+:\s?(.+)',
+    'updated_date':             r'modified\.+:\s?(.+)',
+    'name_servers':             r'nserver\.+:\s*(.+)',
+    'status':                   r'status\.+:\s?(.+)',
+}


### PR DESCRIPTION
Added support for .SE, .NU and .FI ccTLDs

```
>>> import whois
>>> print(whois.query("google.se").__dict__)
{'name': 'google.se', 'registrar': 'MarkMonitor Inc', 'creation_date': datetime.datetime(2003, 8, 27, 0, 0), 'expiration_date': datetime.datetime(2020, 10, 20, 0, 0), 'last_updated': datetime.datetime(2019, 9, 18, 0, 0), 'status': 'serverDeleteProhibited', 'name_servers': {'ns1.google.com', 'ns3.google.com', 'ns2.google.com', 'ns4.google.com'}}

>>> print(whois.query("google.nu").__dict__)
{'name': 'google.nu', 'registrar': 'MarkMonitor Inc', 'creation_date': datetime.datetime(1999, 6, 7, 0, 0), 'expiration_date': datetime.datetime(2020, 6, 7, 0, 0), 'last_updated': datetime.datetime(2019, 10, 1, 0, 0), 'status': 'ok', 'name_servers': {'ns1.google.com', 'ns3.google.com', 'ns2.google.com', 'ns4.google.com'}}

>>> print(whois.query("google.fi").__dict__)
{'name': 'google.fi', 'registrar': 'MarkMonitor Inc.', 'creation_date': datetime.datetime(2006, 6, 30, 0, 0), 'expiration_date': datetime.datetime(2020, 7, 4, 10, 15, 55), 'last_updated': datetime.datetime(2019, 6, 2, 0, 0), 'status': 'Registered', 'name_servers': {'ns1.google.com', 'ns3.google.com', 'ns2.google.com', 'ns4.google.com'}}