### PR TITLE
Make all statusses accessible

### DIFF
--- a/whois/_3_adjust.py
+++ b/whois/_3_adjust.py
@@ -15,6 +15,7 @@ class Domain:
         self.expiration_date = str_to_date(data['expiration_date'][0])
         self.last_updated = str_to_date(data['updated_date'][0])
         self.status = data['status'][0].strip()
+        self.statuses = list(set([s.strip() for s in data['status']])) # list(set(...))) to deduplicate
 
         # name_servers
         tmp = []


### PR DESCRIPTION
Some domains have multiple status tags, at least in the .com TLD.

I don't feel comfortable sharing the actual domain that I've run into this issue with, because it's malicious. However the raw whois results look contain this:

```
Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
Domain Status: clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited
Domain Status: clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited
Domain Status: clientHold https://icann.org/epp#clientHold
```

This PR adds a property `statuses` that contains an array of all the statuses.

Sample code:
```python
import sys
import whois
from pprint import pprint

domain = whois.query(sys.argv[1])
pprint(domain.statuses)
```

Output:
```python
['clientHold https://icann.org/epp#clientHold',
 'clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited',
 'clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited',
 'clientTransferProhibited https://icann.org/epp#clientTransferProhibited']
```