### PR TITLE
Add .nl TLD support

### DIFF
--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -14,6 +14,13 @@ com = {
     'emails':					r'[\w.-]+@[\w.-]+\.[\w]{2,4}',
 }
 
+nl = {
+    'extend': 'com',
+    'domain_name':				r'Domain name:\s?(.+)',
+    'updated_date':				r'Updated Date:\s?(.+)',
+    'name_servers':				r'Domain nameservers:(?:\s+(\S+)\n)(?:\s+(\S+)\n)?(?:\s+(\S+)\n)?(?:\s+(\S+)\n)?(?:\s+(\S+)\n)?(?:\s+(\S+)\n)?\n?',
+}
+
 net = {
     'extend': 'com',
 }


### PR DESCRIPTION
Title says it most.

The regex for name servers is a bit nasty. In the code is the best I could come up with. It supports up to 6 entries, which should be enough, right...

One might consider a trick like that for the registrar too. Both records are multi-lined and, unlike most registrars, not prefixed on every line.  

Example:
```python3
domain = whois.query("google.nl")
pprint(domain.__dict__)

{'creation_date': datetime.datetime(1999, 5, 27, 0, 0),
 'expiration_date': None,
 'last_updated': datetime.datetime(2015, 12, 30, 0, 0),
 'name': 'google.nl',
 'name_servers': {'ns1.google.com',
                  'ns2.google.com',
                  'ns3.google.com',
                  'ns4.google.com'},
 'registrar': 'MarkMonitor Inc.',
 'status': 'active',
 'statuses': ['active']}
```

From whois:
```
$ whois google.nl
Domain name: google.nl
Status:      active

Registrar:
   MarkMonitor Inc.
   3540 East Longwing Lane
   Suite 300
   83646 Meridian
   United States of America

Abuse Contact:

Creation Date: 1999-05-27

Updated Date: 2015-12-30

DNSSEC:      no

Domain nameservers:
   ns1.google.com
   ns2.google.com
   ns3.google.com
   ns4.google.com

Record maintained by: NL Domain Registry
```