### PR TITLE
fix missing registrar and expiration date for .pl domains

### DIFF
--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -33,7 +33,7 @@ uk = {
     'registrant':				r'Registrant:\n\s*(.+)',
 
     'creation_date':			r'Registered on:\s*(.+)',
-    
+
     'expiration_date':			r'Expiry date:\s*(.+)',
 
     'updated_date':				r'Last updated:\s*(.+)',
@@ -60,9 +60,10 @@ ac_uk = {
 
 pl = {
     'extend': 'uk',
-
+    'registrar':                r'\nREGISTRAR:\s*(.+)\n',
     'creation_date':			r'\ncreated:\s*(.+)\n',
     'updated_date':				r'\nlast modified:\s*(.+)\n',
+    'expiration_date':          r'\noption expiration date:\s*(.+)\n',
 
     'name_servers':				r'\nnameservers:\s*(.+)\n\s*(.+)\n',
     'status':					r'\nStatus:\n\s*(.+)',
@@ -98,7 +99,7 @@ lt = {
     'status':                   r'\nStatus:\s?(.+)',
     'domain_name':				r'Domain:\s?(.+)',
     'creation_date':			r'Registered:\s?(.+)',
-    'expiration_date':			r'Expires:\s?(.+)',  
+    'expiration_date':			r'Expires:\s?(.+)',
     'name_servers':				r'Nameserver:\s*(.+)\s*',
 }
 


### PR DESCRIPTION
Title says it all, fix missing registrar and expiration date for .pl domains

```
$ whois google.pl

DOMAIN NAME:           google.pl
registrant type:       organization
nameservers:           ns1.google.com.
                       ns2.google.com.
                       ns3.google.com.
                       ns4.google.com.
created:               2002.09.19 13:00:00
last modified:         2019.08.17 11:36:41
renewal date:          2020.09.18 14:00:00

option created:        2017.10.14 09:30:46
option expiration date:       2020.10.14 09:30:46

dnssec:                Unsigned


REGISTRAR:
Markmonitor, Inc.
3540 East Longwing Lane, Suite 300
Meridian, Idaho 83646
United States
+1.2083895740
ccops@markmonitor.com

WHOIS database responses and Registrant data available at: https://dns.pl/en/whois

WHOIS displays data with a delay not exceeding 15 minutes in relation to the .pl Registry system
```

```
>>> import whois
>>> domain = whois.query('google.pl')
>>> print(domain.__dict__)
{'name': 'google.pl', 'registrar': 'Markmonitor, Inc.', 'creation_date': datetime.datetime(2002, 9, 19, 13, 0), 'expiration_date': datetime.datetime(2020, 10, 14, 9, 30, 46), 'last_updated': datetime.datetime(2019, 8, 17, 11, 36, 41), 'status': '', 'statuses': [''], 'name_servers': {'ns1.google.com', 'ns2.google.com'}}
```