### PR TITLE
Fix regexes for .ca

### DIFF
--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -284,17 +284,6 @@ io = {
 
 ca = {
     'extend': 'com',
-
-    'domain_name':				r'domain:\s?(.+)',
-    'registrar':				r'registrar:\s*(.+)',
-    'registrant':				r'contact:\s?(.+)',
-
-    'creation_date':			r'created:\s?(.+)',
-    'expiration_date':			None,
-    'updated_date':				r'last-update:\s?(.+)',
-
-    'name_servers':				r'nserver:\s*(.+)',
-    'status':					r'status:\s?(.+)',
 }
 
 br = {


### PR DESCRIPTION
I was unable to get results trying to query any .ca domains. After some debugging I found that the regexes set for .ca weren't matching the results I was getting on the command line from `whois`. I've tested a few hundred .ca domains with this change and they seem to populate properly.

I'm on Ubuntu 20.04 using whois 5.5.6.