### PR TITLE
add expiration date .fr

### DIFF
--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -270,7 +270,7 @@ fr = {
     'registrant':				r'contact:\s?(.+)',
 
     'creation_date':			r'created:\s?(.+)',
-    'expiration_date':			None,
+    'expiration_date':			r'Expiry Date:\s?(.+)',
     'updated_date':				r'last-update:\s?(.+)',
 
     'name_servers':				r'nserver:\s*(.+)',


### PR DESCRIPTION
Hi!

This PR adds expiration date parsing for `.fr` domains.

```
$ python3 -c 'import whois; domain = whois.query("facebook.fr"); print(domain.expiration_date)'
2021-05-10 13:47:36
$ python3 -c 'import whois; domain = whois.query("lemonde.fr"); print(domain.expiration_date)'
2021-02-11 04:00:07
```

:sunflower: 