### PR TITLE
Force adding LANG environment for reliable output

### DIFF
--- a/whois/_1_query.py
+++ b/whois/_1_query.py
@@ -57,7 +57,7 @@ def _do_whois_query(dl, ignore_returncode):
     """
         Linux 'whois' command wrapper
     """
-    p = subprocess.Popen(['whois', '.'.join(dl)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    p = subprocess.Popen(['whois', '.'.join(dl)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env={"LANG": "ja"})
     r = p.communicate()[0]
     r = r.decode() if PYTHON_VERSION == 3 else r
     if not ignore_returncode and p.returncode != 0 and p.returncode != 1:


### PR DESCRIPTION
##  Summary
`whois` command has inconsistent parameters between distros.
This resulted an inconsistent output on `.co.jp` and `.jp`.

To resolve this issue, LANG parameter on env was explicitly added to make sure that Japanese NICs always return responses in Japanese.
It is also good to note that LANG parameter is exclusively used for Japanese NICs at the current stage. 😞 


## Reference

Unix Official Guideline:
https://www.unix.com/man-page/redhat/1/whois/
```
ENVIRONMENT
LANG
When querying whois.nic.ad.jp and whois.jprs.jp English text is requested unless the LANG or LC_MESSAGES environment variables specify a Japanese locale.
```

On Debian:
https://manpages.debian.org/testing/whois/whois.1.en.html
```
ENVIRONMENT
LANG
When querying whois.nic.ad.jp and whois.jprs.jp English text is requested unless the LANG or LC_MESSAGES environment variables specify a Japanese locale.
```

On FreeBSD: https://www.freebsd.org/cgi/man.cgi?query=whois
*There wasn't LANG variable taken into account. It turns out that Japanese output was always printed as a result.*