### PR TITLE
Added required keys for kz domain

### DIFF
--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -547,10 +547,12 @@ kz = {
     'extend': None,
     'domain_name':              r'Domain name\.+:\s(.+)',
     'registrar':                r'Current Registar:\s(.+)',
+    'registrant_country':       r'Country\.+:\s?(.+)',
     'expiration_date':          None,
     'name_servers':             r'server.*:\s(.+)',
     'creation_date':            r'Domain created:\s(.+)',
-    'updated_date':             r'Last modified :\s(.+)'
+    'updated_date':             r'Last modified :\s(.+)',
+    'status':                   r'Domain status :\s?(.+)'
 }
 
 cl = {


### PR DESCRIPTION
Hi just putting in a pull request for issue: Add .kz #26

I encountered an exception when testing:
Python 3.7.6 (default, Sep 28 2020, 21:47:29) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import whois
>>> whois.query('primeminister.kz')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/mnt/g/Programming/python/dev/python-whois/whois/__init__.py", line 75, in query
    return Domain(pd) if pd['domain_name'][0] else None
  File "/mnt/g/Programming/python/dev/python-whois/whois/_3_adjust.py", line 14, in __init__
    self.registrant_country = data['registrant_country'][0].strip()
KeyError: 'registrant_country'

Added a few keys to KZ in tld_regexpr.py needed by the Domain class.