### PR TITLE
Add South Africa .za https://www.zadna.org.za

### DIFF
--- a/README
+++ b/README
@@ -84,6 +84,7 @@ ccTLD
 - рф (xn--p1ai)
 - in
 - ua
+- co.za
 
 TLD
 - download

--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -22,6 +22,10 @@ nl = {
     'name_servers':				r'Domain nameservers:(?:\s+(\S+)\n)(?:\s+(\S+)\n)?(?:\s+(\S+)\n)?(?:\s+(\S+)\n)?(?:\s+(\S+)\n)?(?:\s+(\S+)\n)?\n?',
 }
 
+za = {
+    'extend': 'com',
+}
+
 net = {
     'extend': 'com',
 }


### PR DESCRIPTION
Add South African domains.

Domains including .co.za .

