### PR TITLE
Correct exception raise for unknown TLD, .nl domain update, PEP8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ docs/_build/
 target/
 
 .idea
+
+whois.exe

--- a/test.py
+++ b/test.py
@@ -124,7 +124,7 @@ for d in DOMAINS.split('\n'):
             message = """
             Error : {},
             On Domain: {}
-            """.format(str(e),d)
+            """.format(str(e), d)
 
 for d in invalidTld.split('\n'):
     if d:
@@ -137,7 +137,7 @@ for d in invalidTld.split('\n'):
             message = """
             Error : {},
             On Domain: {}
-            """.format(str(e),d)
+            """.format(str(e), d)
             print('Caught UnknownTld Exception')
             print(e)
 
@@ -152,7 +152,7 @@ for d in failedParsing.split('\n'):
             message = """
             Error : {},
             On Domain: {}
-            """.format(str(e),d)
+            """.format(str(e), d)
             print('Caught FailedParsingWhoisOutput Exception')
             print(e)
 
@@ -167,7 +167,7 @@ for d in unknownDateFormat.split('\n'):
             message = """
             Error : {},
             On Domain: {}
-            """.format(str(e),d)
+            """.format(str(e), d)
             print('Caught UnknownDateFormat Exception')
             print(e)
 
@@ -175,6 +175,6 @@ for d in unknownDateFormat.split('\n'):
 report_str = """
 Failure during test : {}
 Domains : {}
-""".format(len(failure),failure)
+""".format(len(failure), failure)
 message = '\033[91m' + report_str + '\x1b[0m'
 print(message)

--- a/whois/_1_query.py
+++ b/whois/_1_query.py
@@ -55,7 +55,7 @@ def do_query(dl, force=0, cache_file=None, slow_down=0, ignore_returncode=0):
 
 
 def _do_whois_query(dl, ignore_returncode):
-    if(platform.system() == 'Windows'):
+    if platform.system() == 'Windows':
         """
             Windows 'whois' command wrapper
         """
@@ -64,9 +64,9 @@ def _do_whois_query(dl, ignore_returncode):
             folder = os.getcwd()
             copy_command = r"copy \\live.sysinternals.com\tools\whois.exe "+folder
             print(copy_command)
-            p = subprocess.call(copy_command,stdout=subprocess.PIPE, stderr=subprocess.STDOUT,shell=True)
+            p = subprocess.call(copy_command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
         # print(p.stdout.read()+' '+p.stderr.read())
-        p = subprocess.Popen(['.\whois', '.'.join(dl)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        p = subprocess.Popen([r'.\whois.exe ', '.'.join(dl)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
     else:
         """

--- a/whois/_2_parse.py
+++ b/whois/_2_parse.py
@@ -38,7 +38,7 @@ def do_parse(whois_str, tld):
         if s == 'not found':
             return
         if s.startswith('no such domain'):
-            # could feed startswith a tuple of strings of expected reponses
+            # could feed startswith a tuple of strings of expected responses
             return
         if s.count('error'):
             return
@@ -49,7 +49,7 @@ def do_parse(whois_str, tld):
     whois_dnssec = whois_str.split("DNSSEC:")
     if len(whois_dnssec) >= 2:
         whois_dnssec = whois_dnssec[1].split("\n")[0]
-        if whois_dnssec.strip() == "signedDelegation":
+        if whois_dnssec.strip() == "signedDelegation" or whois_dnssec.strip() == "yes":
             r['DNSSEC'] = True
 
     # split whois_str to remove first IANA part showing info for TLD only

--- a/whois/_3_adjust.py
+++ b/whois/_3_adjust.py
@@ -43,6 +43,10 @@ class Domain:
 
         if 'owner' in data:
             self.owner = data['owner'][0].strip()
+        if 'abuse_contact' in data:
+            self.abuse_contact = data['abuse_contact'][0].strip()
+        if 'reseller' in data:
+            self.reseller = data['reseller'][0].strip()
 
 
 # http://docs.python.org/library/datetime.html#strftime-strptime-behavior
@@ -96,9 +100,9 @@ def str_to_date(text):
         return
 
     text = text.replace('(jst)', '(+0900)')
-    text = re.sub('(\+[0-9]{2}):([0-9]{2})', '\\1\\2', text)
-    text = re.sub('(\+[0-9]{2})$', '\\1:00', text)
-    text = re.sub('(\ #.*)', '', text)
+    text = re.sub(r'(\+[0-9]{2}):([0-9]{2})', '\\1\\2', text)
+    text = re.sub(r'(\+[0-9]{2})$', '\\1:00', text)
+    text = re.sub(r'(\ #.*)', '', text)
     # hack for 1st 2nd 3rd 4th etc
     # better here https://stackoverflow.com/questions/1258199/python-datetime-strptime-wildcard
     text = re.sub(r"(\d+)(st|nd|rd|th) ", r"\1 ", text)
@@ -116,7 +120,7 @@ def str_to_date(text):
 
 
 def str_to_date_py2(text):
-    tmp = re.findall('\+([0-9]{2})00', text)
+    tmp = re.findall(r'\+([0-9]{2})00', text)
     time_zone = 0
 
     if tmp:
@@ -125,17 +129,17 @@ def str_to_date_py2(text):
         time_zone = 0
     
     del tmp
-    tmp = re.findall('\+([0-9]{2})$', text)
+    tmp = re.findall(r'\+([0-9]{2})$', text)
 
     if tmp:
         time_zone = int(tmp[0])
-        text = re.sub('(.*)(\+[0-9]{2})$', '\\1', text)
+        text = re.sub(r'(.*)(\+[0-9]{2})$', '\\1', text)
     else:
         time_zone = 0
     
-    for format in DATE_FORMATS:
+    for date_format in DATE_FORMATS:
         try:
-            return datetime.datetime.strptime(text, format) + datetime.timedelta(hours=time_zone)
+            return datetime.datetime.strptime(text, date_format) + datetime.timedelta(hours=time_zone)
         except ValueError:
             pass
 

--- a/whois/__init__.py
+++ b/whois/__init__.py
@@ -27,7 +27,6 @@ from .exceptions import UnknownTld, FailedParsingWhoisOutput, UnknownDateFormat,
 CACHE_FILE = None
 SLOW_DOWN = 0
 
-import sys
 
 def query(domain, force=0, cache_file=None, slow_down=0, ignore_returncode=0):
     """
@@ -65,10 +64,10 @@ def query(domain, force=0, cache_file=None, slow_down=0, ignore_returncode=0):
         tld = d[-1]
 
     if tld not in TLD_RE.keys():
-        print(f'Unknown TLD: .{tld}\nValid TLDs: ', end ="")
+        print(f'Unknown TLD: .{tld}\nValid TLDs: ', end="")
         for tld in sorted(list(TLD_RE.keys())):
-            print(f'.{tld}', end =" ")
-        sys.exit(1)
+            print(f'.{tld}', end=" ")
+        raise UnknownTld
 
     while 1:
         pd = do_parse(do_query(d, force, cache_file, slow_down, ignore_returncode), tld)

--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -21,7 +21,7 @@ ac_uk = {
 
     'domain_name':              r'Domain:\n\s?(.+)',
 
-    'owner':                r'Domain Owner:\n\s?(.+)',
+    'owner':                    r'Domain Owner:\n\s?(.+)',
     'registrar':                r'Registered By:\n\s?(.+)',
     'registrant':               r'Registered Contact:\n\s*(.+)',
     'expiration_date':          r'Renewal date:\n\s*(.+)',
@@ -487,11 +487,13 @@ ninja = {
 nl = {
     'extend': 'com',
 
+    'expiration_date':          None,
+    'registrant_country':       None,
+
     'domain_name':              r'Domain name:\s?(.+)',
-
-    'updated_date':             r'Updated Date:\s?(.+)',
-
     'name_servers':             r'Domain nameservers:(?:\s+(\S+)\n)(?:\s+(\S+)\n)?(?:\s+(\S+)\n)?(?:\s+(\S+)\n)?(?:\s+(\S+)\n)?(?:\s+(\S+)\n)?\n?',
+    'reseller':                 r'Reseller:\s?(.+)',
+    'abuse_contact':            r'Abuse Contact:\s?(.+)',
 }
 
 


### PR DESCRIPTION
PR includes:
- added abuse_contact and reseller optional attributes (.nl TLD)
- extended DNSSEC check for .nl TLD ('yes')
- corrected mistake in Windows process starter (missing '.exe')
- now raises UnknownTld exception instead of terminating at unknown TLD
- various PEP8/code format improvements

TODO:
- version number?
- add abuse contact to more TLDs