### PR TITLE
Adds new TLDs by request

### DIFF
--- a/README
+++ b/README
@@ -44,7 +44,8 @@ google.com
 
 ccTLD & TLD support
 ===================
-.ac_uk
+.ac.uk
+.am
 .ar
 .at
 .au
@@ -59,9 +60,12 @@ ccTLD & TLD support
 .club
 .cn
 .co
-.co_jp
+.co.il
+.co.jp
 .com
-.com_au
+.com.au
+.com.tr
+.cr
 .cz
 .de
 .download
@@ -69,17 +73,25 @@ ccTLD & TLD support
 .education
 .eu
 .fi
+.fm
 .fr
+.game
+.global
+.hk
 .id
-.in_
+.ie
+.im
+.in
 .info
+.ink
 .io
 .ir
-.is_is
+.is
 .it
 .jp
 .kr
 .kz
+.link
 .lt
 .lv
 .me
@@ -98,11 +110,14 @@ ccTLD & TLD support
 .pharmacy
 .pl
 .press
+.pt
+.pub
 .pw
 .rest
 .ru
-.ru_rf
+.ru.rf
 .rw
+.sale
 .se
 .security
 .sh
@@ -113,6 +128,7 @@ ccTLD & TLD support
 .tel
 .theatre
 .tickets
+.trade
 .tv
 .ua
 .uk

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ from distutils.core import setup
 
 setup(
     name='whois',
-    version='0.9.8',
+    version='0.9.10',
     description='Python package for retrieving WHOIS information of domains.',
     author='DannyCork',
     author_email='ddarko@ddarko.org',
     license='MIT http://www.opensource.org/licenses/mit-license.php',
-    download_url='https://github.com/DannyCork/python-whois/releases/tag/0.8',
+    download_url='https://github.com/DannyCork/python-whois/releases/tag/0.9.10',
     url='https://github.com/DannyCork/python-whois/',
     platforms=['any'],
     packages=['whois'],

--- a/test.py
+++ b/test.py
@@ -93,6 +93,21 @@ DOMAINS = '''
     google.rw
     tut.by
     guinness.ie
+    google.com.tr
+    google.sale
+    google.link
+    google.game
+    google.trade
+    google.ink
+    google.pub
+    google.im
+    google.am
+    google.fm
+    google.hk
+    google.cr
+    google.global
+    google.co.il
+    google.pt
 '''
 
 failure = list()

--- a/whois/_1_query.py
+++ b/whois/_1_query.py
@@ -75,7 +75,7 @@ def _do_whois_query(dl, ignore_returncode):
         p = subprocess.Popen(['whois', '.'.join(dl)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
     r = p.communicate()[0]
-    r = r.decode() if PYTHON_VERSION == 3 else r
+    r = r.decode(errors='ignore') if PYTHON_VERSION == 3 else r
     if not ignore_returncode and p.returncode != 0 and p.returncode != 1:
         raise WhoisCommandFailed(r)
     return r

--- a/whois/_3_adjust.py
+++ b/whois/_3_adjust.py
@@ -41,17 +41,23 @@ class Domain:
 
                 self.name_servers.add(x.lower())
 
+        if not self.name_servers:
+            self.name_servers = None
+
         if 'owner' in data:
             self.owner = data['owner'][0].strip()
         if 'abuse_contact' in data:
             self.abuse_contact = data['abuse_contact'][0].strip()
         if 'reseller' in data:
             self.reseller = data['reseller'][0].strip()
+        if 'registrant' in data:
+            self.registrant = data['registrant'][0].strip()
 
 
 # http://docs.python.org/library/datetime.html#strftime-strptime-behavior
 DATE_FORMATS = [
     '%d-%b-%Y',                     # 02-jan-2000
+    '%d-%m-%Y',                     # 02-01-2000
     '%d.%m.%Y',                     # 02.02.2000
     '%d/%m/%Y',                     # 01/06/2011
     '%Y-%m-%d',                     # 2000-01-02
@@ -63,7 +69,7 @@ DATE_FORMATS = [
     '%Y-%m-%d %H:%M:%S',            # 2011-09-08 14:44:51
     '%Y-%m-%d %H:%M:%S%z',          # 2025-04-27 02:54:19+03:00
     '%Y-%m-%d %H:%M:%S CLST',       # 2011-09-08 14:44:51 CLST CL
-    '%Y-%m-%d %H:%M:%S.%f',       # 2011-09-08 14:44:51 CLST CL
+    '%Y-%m-%d %H:%M:%S.%f',         # 2011-09-08 14:44:51 CLST CL
     '%d.%m.%Y  %H:%M:%S',           # 19.09.2002 13:00:00
     '%d-%b-%Y %H:%M:%S %Z',         # 24-Jul-2009 13:20:03 UTC
     '%Y/%m/%d %H:%M:%S (%z)',       # 2011/06/01 01:05:01 (+0900)
@@ -90,13 +96,15 @@ DATE_FORMATS = [
     '%A %d %B %Y',                  # Tuesday 21 June 2011
     '%Y-%m-%d %H:%M:%S (%Z+0:00)',  # 2007-12-24 10:24:32 (gmt+0:00)
     '%B %d %Y',                     # January 01 2000
+    '%Y-%b-%d',                     # 2021-Oct-18
+    '%d/%m/%Y %H:%M:%S',            # 08/09/2011 14:44:51
 ]
 
 
 def str_to_date(text):
     text = text.strip().lower()
 
-    if not text or text == 'not defined':
+    if not text or text == 'not defined' or text == 'n/a':
         return
 
     text = text.replace('(jst)', '(+0900)')

--- a/whois/__init__.py
+++ b/whois/__init__.py
@@ -45,21 +45,29 @@ def query(domain, force=0, cache_file=None, slow_down=0, ignore_returncode=0):
     if len(d) == 1:
         return None
 
-    if domain.endswith('.co.jp'):
-        tld = 'co_jp'
-    elif domain.endswith('.is'):
-        tld = 'is_is'
-    elif domain.endswith('.xn--p1ai'):
-        tld = 'ru_rf'
-    elif domain.endswith('.ac.uk') and len(d) > 2:
+    if domain.endswith('.ac.uk') and len(d) > 2:
         tld = 'ac_uk'
+    elif domain.endswith('co.il') and len(d) > 2:
+        tld = 'co_il'
+    elif domain.endswith('.co.jp') and len(d) > 2:
+        tld = 'co_jp'
+    elif domain.endswith('.com.au') and len(d) > 2:
+        tld = 'com_au'
+    elif domain.endswith('com.tr') and len(d) > 2:
+        tld = 'com_tr'
+    elif domain.endswith('global'):
+        tld = 'global_'
+    elif domain.endswith('.id'):
+        tld = 'id_'
+    elif domain.endswith('.in'):
+        tld = 'in_'
+    elif domain.endswith('.is'):
+        tld = 'is_'
     elif domain.endswith('.name'):
         d[0] = 'domain=' + d[0]
         tld = d[-1]
-    elif domain.endswith('.in'):
-        tld = 'in_'
-    elif domain.endswith('.com.au'):
-        tld = 'com_au'
+    elif domain.endswith('.xn--p1ai'):
+        tld = 'ru_rf'
     else:
         tld = d[-1]
 

--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -32,6 +32,21 @@ ac_uk = {
 
 }
 
+am = {
+    'domain_name':              r'Domain name:\s+(.+)',
+    'status':                   r'Status:\s(.+)',
+
+    'registrar':                r'Registrar:\s+(.+)',
+    'registrant':               r'Registrant:\s+(.+)',
+    'registrant_country':       r'Registrant:\n.+\n.+\n.+\n\s+(.+)',
+
+    'creation_date':            r'Registered:\s+(.+)',
+    'expiration_date':          r'Expires:\s+(.+)',
+    'updated_date':             r'Last modified:\s+(.+)',
+
+    'name_servers':             r'DNS servers.*:\n(?:\s+(\S+)\n)(?:\s+(\S+)\n)?(?:\s+(\S+)\n)?(?:\s+(\S+)\n)\n?',
+}
+
 ar = {
     'extend': 'com',
 
@@ -181,7 +196,40 @@ co = {
 }
 
 com_au = {
-    'extend': 'au'
+    'extend': 'au',
+}
+
+com_tr = {
+    'extend': 'com',
+
+    'domain_name':          r'\*\* Domain Name:\s?(.+)',
+
+    'registrar':            r'Organization Name\s+:\s?(.+)',
+    'registrant':           r'\*\* Registrant:\s+?(.+)',
+    'registrant_country':   None,
+
+    'creation_date':        r'Created on..............:\s?(.+).',
+    'expiration_date':      r'Expires on..............:\s?(.+).',
+    'updated_date':         '',
+
+    'name_servers':         r'\*\* Domain Servers:\n(?:(\S+)\n)(?:(\S+)\n)?(?:(\S+)\n)?(?:(\S+)\n)?(?:(\S+)\n)?(?:(\S+)\n)\n?',
+    'status':               None,
+}
+
+co_il = {
+    'extend': 'com',
+
+    'domain_name':              r'domain:\s*(.+)',
+    'registrar':                r'registrar name:\s*(.+)',
+    'registrant':               None,
+    'registrant_country':       None,
+
+    'creation_date':            None,
+    'expiration_date':          r'validity:\s*(.+)',
+    'updated_date':             None,
+
+    'name_servers':             r'nserver:\s*(.+)',
+    'status':                   r'status:\s*(.+)',
 }
 
 co_jp = {
@@ -194,18 +242,24 @@ co_jp = {
     'updated_date':             r'\[最終更新\]\s?(.+)',
 }
 
+cr = {
+    'extend': 'cz',
+}
+
 cz = {
     'extend': 'com',
 
-    'domain_name':              r'Domain:\s?(.+)',
+    'domain_name':              r'domain:\s?(.+)',
     'registrar':                r'registrar:\s?(.+)',
     'registrant':               r'registrant:\s?(.+)',
+    'registrant_country':       None,
 
     'creation_date':            r'registered:\s?(.+)',
     'expiration_date':          r'expire:\s?(.+)',
     'updated_date':             r'changed:\s?(.+)',
 
     'name_servers':             r'nserver:\s*(.+) ',
+    'status':                   r'status:\s*(.+)',
 }
 
 de = {
@@ -277,6 +331,10 @@ fi = {
     'status':                   r'status\.+:\s?(.+)',
 }
 
+fm = {
+    'extend': 'com',
+}
+
 
 fr = {
     'extend': 'com',
@@ -293,8 +351,34 @@ fr = {
     'status':                   r'status:\s?(.+)',
 }
 
+game = {
+    'extend': 'store'
+}
 
-id = {
+global_ = {
+    'extend': 'store',
+
+    'name_servers': r'Name Server: (.+)',
+}
+
+hk = {
+    'extend': 'com',
+
+    'domain_name':				r'Domain Name:\s+(.+)',
+
+    'registrar':				r'Registrar Name:\s?(.+)',
+    'registrant':				r'Company English Name.*:\s?(.+)',
+    'registrant_country':       None,
+
+    'creation_date':			r'Domain Name Commencement Date:\s?(.+)',
+    'expiration_date':			r'Expiry Date:\s?(.+)',
+    'updated_date':				None,
+
+    'name_servers':				r'Name Servers Information:\n\n(?:(\S+)\n)(?:(\S+)\n)(?:(\S+)\n)?(?:(\S+)\n)?\n?',
+    'status':					None,
+}
+
+id_ = {
     'extend': 'com',
 
     'registrar':                r'Sponsoring Registrar Organization:\s?(.+)',
@@ -302,6 +386,24 @@ id = {
     'creation_date':            r'Created On:\s?(.+)',
     'expiration_date':          r'Expiration Date:\s?(.+)',
     'updated_date':             r'Last Updated On:\s?(.+)$',
+}
+
+ie = {
+    'extend': 'com'
+}
+
+im = {
+    'domain_name':              r'Domain Name:\s+(.+)',
+    'status':                   None,
+
+    'registrar':                None,
+    'registrant_country':       None,
+
+    'creation_date':            '',
+    'expiration_date':          r'Expiry Date:\s?(.+)',
+    'updated_date':             '',
+
+    'name_servers':             r'Name Server:(.+)',
 }
 
 in_ = {
@@ -312,8 +414,8 @@ info = {
     'extend': 'com'
 }
 
-ie = {
-    'extend': 'com'
+ink = {
+    'extend': 'store'
 }
 
 io = {
@@ -341,7 +443,7 @@ ir = {
 }
 
 
-is_is = {
+is_ = {
     'domain_name':              r'domain:\s?(.+)',
 
     'registrar':                None,
@@ -419,6 +521,10 @@ kz = {
 
     'name_servers':             r'server.*:\s(.+)',
     'status':                   r'Domain status :\s?(.+)'
+}
+
+link = {
+    'extend': 'store'
 }
 
 lt = {
@@ -610,6 +716,25 @@ pro = {
     'extend': 'com',
 }
 
+pt = {
+    'extend': 'com',
+
+    'domain_name':              r'Domain:\s?(.+)',
+
+    'registrar':                None,
+
+    'creation_date':            r'Creation Date:\s?(.+)',
+    'expiration_date':          r'Expiration Date:\s?(.+)',
+    'updated_date':             None,
+
+    'name_servers':             r'Name Server:\s*(.+)',
+    'status':                   r'Domain Status:\s?(.+)',
+}
+
+pub = {
+    'extend': 'store'
+}
+
 pw = {
     'extend': 'com',
 
@@ -652,6 +777,10 @@ ru_rf = {
 
     'name_servers':             r'\nnserver:\s*(.+)',
     'status':                   r'\nstate:\s*(.+)',
+}
+
+sale = {
+    'extend': 'store'
 }
 
 security = {
@@ -731,6 +860,10 @@ theatre = {
 }
 
 tickets = {
+    'extend': 'store'
+}
+
+trade = {
     'extend': 'store'
 }
 


### PR DESCRIPTION
### Changes:
Propose to bump to 9.9.10 (Please create tag @DannyCork)

Now ignore decode errors (com.tr on Windows returns non-UTF-8 characters)

When no name servers are defined, now return None instead of 'set()'

Return registrant when defined

Add two missing dateformats

Adds support for:
- .com.tr
- .sale
- .link
- .game
- .trade
- .ink
- .pub
- .am
- .im
- .fm
- .hk
- .cr
- .global
- .co.il
- .in
- .pt



### Issues:
Fixes #138 
Fixes #130
Fixes #128
Fixes #126
Fixes #111 
Fixes #83
Fixes #37 