### PR TITLE
Fix nameserver parsing for .nl TLD when glue records are present

### DIFF
--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -613,7 +613,20 @@ nl = {
     'registrant_country':       None,
 
     'domain_name':              r'Domain name:\s?(.+)',
-    'name_servers':             r'Domain nameservers:(?:\s+(\S+)\n)(?:\s+(\S+)\n)?(?:\s+(\S+)\n)?(?:\s+(\S+)\n)?(?:\s+(\S+)\n)?(?:\s+(\S+)\n)?\n?',
+    'name_servers':             (
+        r'''(?x:
+            Domain\ nameservers:[ \t]*\n
+            (?:[ \t]+) (\S+) (?:[ \t]+\S+)? \n       # ns1.tld.nl [A?]
+            (?:(?:[ \t]+) (\S+) (?:[ \t]+\S+)? \n)?  # opt-ns2.tld.nl [A?]
+            (?:(?:[ \t]+) (\S+) (?:[ \t]+\S+)? \n)?  # opt-ns2.tld.nl [AAAA?]
+            (?:(?:[ \t]+) (\S+) (?:[ \t]+\S+)? \n)?  # opt-ns3.tld.nl [A?]
+            (?:(?:[ \t]+) (\S+) (?:[ \t]+\S+)? \n)?  # opt-ns3.tld.nl [AAAA?]
+            (?:(?:[ \t]+) (\S+) (?:[ \t]+\S+)? \n)?  # opt-ns4.tld.nl [A?]
+            (?:(?:[ \t]+) (\S+) (?:[ \t]+\S+)? \n)?  # opt-ns4.tld.nl [AAAA?]
+            (?:(?:[ \t]+) (\S+) (?:[ \t]+\S+)? \n)?  # opt-ns5.tld.nl [A?]
+            (?:(?:[ \t]+) (\S+) (?:[ \t]+\S+)? \n)?  # opt-ns5.tld.nl [AAAA?]
+            # Don't check for final LF; there might be even more records..
+        )'''),
     'reseller':                 r'Reseller:\s?(.+)',
     'abuse_contact':            r'Abuse Contact:\s?(.+)',
 }


### PR DESCRIPTION
Before:

    >>> import whois; q = whois.query('wctegeltje.nl'); q.__dict__['name_servers']
    {'ns1.osso.nl', 'ns2.osso.nl', 'ns3.osso.io'}

    >>> import whois; q = whois.query('osso.nl'); q.__dict__['name_servers']

After:

    >>> import whois; q = whois.query('wctegeltje.nl'); q.__dict__['name_servers']
    {'ns3.osso.io', 'ns2.osso.nl', 'ns1.osso.nl'}

    >>> import whois; q = whois.query('osso.nl'); q.__dict__['name_servers']
    {'ns3.osso.io', 'ns2.osso.nl', 'ns1.osso.nl'}

Additionally: uses re.VERBOSE (re.X) to explain what we're doing.

Fixes #157