### PR TITLE
Fix bug_report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,9 @@
 ---
-Name: Bug report
-About: Create a report to help us improve
-Title: ''
-Labels: ''
-Assignees: ''
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
 
 ---
 


### PR DESCRIPTION
Previously I thought all programming languages will identify "Cork"=="cork" like Scratch but of f*** Ruby (the language that GitHub uses) but didn't think about it so it raises error 👎🏻 

So I fix the template file.