### PR TITLE
Support .ax/.gy TLD, make .jp out consistent

### DIFF
--- a/whois/_1_query.py
+++ b/whois/_1_query.py
@@ -65,13 +65,14 @@ def _do_whois_query(dl: List[str], ignore_returncode: bool) -> str:
             print(copy_command)
             subprocess.call(copy_command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
         # print(p.stdout.read()+' '+p.stderr.read())
-        p = subprocess.Popen([r'.\whois.exe ', '.'.join(dl)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        p = subprocess.Popen([r'.\whois.exe ', '.'.join(dl)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env={"LANG": "en"})
 
     else:
         """
             Linux 'whois' command wrapper
         """
-        p = subprocess.Popen(['whois', '.'.join(dl)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        # LANG=en is added to make the ".jp" output consist across all environments
+        p = subprocess.Popen(['whois', '.'.join(dl)], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env={"LANG": "en"})
 
     r = p.communicate()[0].decode(errors='ignore')
     if not ignore_returncode and p.returncode != 0 and p.returncode != 1:

--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -1255,5 +1255,9 @@ ax = {
     'updated_date':             r'Information Updated:\s?(.+)',
 }
 
+gy = {
+     'extend': 'com',
+}
+
 # Multiple initialization
 ca = rw = mu = bank

--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -1244,5 +1244,16 @@ za = {
     'extend': 'com',
 }
 
+ax = {
+    'extend': 'com',
+    'domain_name':              r'domain...............:\s?(.+)',
+
+    'registrar':                r'registrar............:\s?(.+)',
+
+    'creation_date':            r'created..............:\s?(.+)',
+    'expiration_date':          r'expires..............:\s?(.+)',
+    'updated_date':             r'Information Updated:\s?(.+)',
+}
+
 # Multiple initialization
 ca = rw = mu = bank


### PR DESCRIPTION
## Summary

1. Add support on .ax/.gy TLD
2. `.jp` and its siblings have been updated last week. it made the output inconsistent again due to the `LANG` environment variable changes across systems, hence adding `LANG=en` environment variable on the `whois` command to make sure that output only comes in English and not in Japanese.