### PR TITLE
fix emptry last modified for au domains (fix for #228 )

### DIFF
--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -102,7 +102,7 @@ at = {
 au = {
     "extend": "com",
     "registrar": r"Registrar Name:\s?(.+)",
-    "updated_date": r"Last Modified:\s?(.+)",
+    "updated_date": r"Last Modified:([^\n]*)", # fix empty LastModified
 }
 
 ax = {


### PR DESCRIPTION
i expect this is actually a problem for more tld's
but for now this fixes all au tld's where Last Modified may be empty string by explicitly not matching \n