### PR TITLE
move sections in do_parse to functions; prepare for handling old style IANA domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ out
 2
 reformat-code.sh
 t1.py
+typescript

--- a/test2.py
+++ b/test2.py
@@ -4,6 +4,7 @@ import os
 import re
 import getopt
 import sys
+import json
 
 Verbose = False
 Failures = {}
@@ -11,9 +12,12 @@ IgnoreReturncode = False
 
 
 def prepItem(d):
-    print("-" * 80)
-    print(d)
+    print("")
+    print(f"test domain: <<<<<<<<<< {d} >>>>>>>>>>>>>>>>>>>>")
 
+def xType(x):
+    s = f"{type(x)}"
+    return s.split("'")[1]
 
 def testItem(d):
     w = whois.query(
@@ -27,9 +31,21 @@ def testItem(d):
         print("None")
         return
 
+    # the 3 date time items can be None if not present or a datetime string
+    # dnssec is a bool
+    # some strings are return as '' when empty (status)
+    # statuses can be a array of one empty string if no data
+
+    # not all values are always present it mainly depends on whet we see in the output of whois
+    # if we return not None: the elements that ars always there ars domain_name and tld
+
     wd = w.__dict__
     for k, v in wd.items():
-        print('%20s\t"%s"' % (k, v))
+        ss = "%-18s %-17s "
+        if isinstance(v, str):
+            print((ss + "'%s'") % (k, xType(v), v))
+        else:
+            print((ss + "%s") % (k, xType(v), v))
 
 
 def errorItem(d, e, what="Generic"):
@@ -74,8 +90,8 @@ def testDomains(aList):
             errorItem(d, e, what="WhoisQuotaExceeded")
         except whois.WhoisPrivateRegistry as e:
             errorItem(d, e, what="WhoisPrivateRegistry")
-        except Exception as e:
-            errorItem(d, e, what="Generic")
+        # except Exception as e:
+        #    errorItem(d, e, what="Generic")
 
 
 def getTestFileOne(fPath, fileData):

--- a/test2.py
+++ b/test2.py
@@ -15,9 +15,11 @@ def prepItem(d):
     print("")
     print(f"test domain: <<<<<<<<<< {d} >>>>>>>>>>>>>>>>>>>>")
 
+
 def xType(x):
     s = f"{type(x)}"
     return s.split("'")[1]
+
 
 def testItem(d):
     w = whois.query(
@@ -37,7 +39,7 @@ def testItem(d):
     # statuses can be a array of one empty string if no data
 
     # not all values are always present it mainly depends on whet we see in the output of whois
-    # if we return not None: the elements that ars always there ars domain_name and tld
+    # if we return not None: the elements that ars always there ars domain_name , tld, dnssec
 
     wd = w.__dict__
     for k, v in wd.items():

--- a/whois/_2_parse.py
+++ b/whois/_2_parse.py
@@ -100,7 +100,7 @@ def handleShortResponse(
     dl: List,
     whois_str: str,
     verbose: bool = False,
-):
+): # returns None or raises one of (WhoisQuotaExceeded, FailedParsingWhoisOutput)
     if verbose:
         d = ".".join(dl)
         print(f"line count < 5:: {tld} {d} {whois_str}", file=sys.stderr)
@@ -150,13 +150,34 @@ def handleShortResponse(
     # ---------------------------------
     raise FailedParsingWhoisOutput(whois_str)
 
-def doDnsSec(whois_str: str):
+def doDnsSec(whois_str: str) -> bool:
     whois_dnssec: Any = whois_str.split("DNSSEC:")
     if len(whois_dnssec) >= 2:
         whois_dnssec = whois_dnssec[1].split("\n")[0]
         if whois_dnssec.strip() == "signedDelegation" or whois_dnssec.strip() == "yes":
             return True
     return False
+
+def doSourceIana(whois_str: str, verbose: bool = False) -> str:
+    # here we can handle the example.com and example.net permanent IANA domains
+
+    if verbose:
+        msg = f"i have seen source: IANA"
+        print(msg, file=sys.stderr)
+
+    whois_splitted = whois_str.split("source:       IANA")
+    if len(whois_splitted) == 2:
+        whois_str = whois_splitted[1] # often this is actually just whitespace
+    return whois_str
+
+def doIfServerNameLookForDomainName(whois_str: str, verbose: bool = False) -> str:
+    # not often available anymore
+    if re.findall(r"Server Name:\s?(.+)", whois_str, re.IGNORECASE):
+        if verbose:
+            msg = f"i have seen Server Name:, looking for Domain Name:"
+            print(msg, file=sys.stderr)
+        whois_str = whois_str[whois_str.find("Domain Name:") :]
+    return whois_str
 
 def do_parse(
     whois_str: str,
@@ -178,27 +199,20 @@ def do_parse(
 
     r["DNSSEC"] = doDnsSec(whois_str) # check the status of DNSSEC
 
-    # this is mostly not available in many tld's anymore, should be investigated
-    # split whois_str to remove first IANA part showing info for TLD only
-    whois_splitted = whois_str.split("source:       IANA")
-    if len(whois_splitted) == 2:
-        whois_str = whois_splitted[1]
+    if "source:       IANA" in whois_str: # prepare for handling historical IANA domains
+        whois_str = doSourceIana(whois_str, verbose)
 
-    # also not available for many modern tld's
-    sn = re.findall(r"Server Name:\s?(.+)", whois_str, re.IGNORECASE)
-    if sn:
-        whois_str = whois_str[whois_str.find("Domain Name:") :]
+    if "Server Name" in whois_str: # handle old type Server Name (not very common anymore)
+        whois_str = doIfServerNameLookForDomainName(whois_str, verbose)
 
-    # return TLD_RE["com"] as default if tld not exists in TLD_RE
-    for k, v in TLD_RE.get(tld, TLD_RE["com"]).items():
-        if k.startswith("_"):
-            # skip meta element like: _server or _privateRegistry
+    for k, v in TLD_RE.get(tld, TLD_RE["com"]).items(): # use TLD_RE["com"] as default if a regex is missing
+        if k.startswith("_"): # skip meta element like: _server or _privateRegistry
             continue
 
+        # Historical: here we use 'empty string' as default, not None
         if v is None:
             r[k] = [""]
         else:
             r[k] = v.findall(whois_str) or [""]
-            # print("DEBUG: Keyval = " + str(r[k]))
 
     return r

--- a/whois/__init__.py
+++ b/whois/__init__.py
@@ -48,7 +48,6 @@ SLOW_DOWN = 0
 Map2Underscore = {
     ".ac.uk": "ac_uk",
     ".co.uk": "co_uk",
-
     ".co.il": "co_il",
     # uganda
     ".ca.ug": "ca_ug",

--- a/whois/__init__.py
+++ b/whois/__init__.py
@@ -47,6 +47,8 @@ SLOW_DOWN = 0
 
 Map2Underscore = {
     ".ac.uk": "ac_uk",
+    ".co.uk": "co_uk",
+
     ".co.il": "co_il",
     # uganda
     ".ca.ug": "ca_ug",

--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -115,7 +115,7 @@ at = {
 au = {
     "extend": "com",
     "registrar": r"Registrar Name:\s?(.+)",
-    "updated_date": r"Last Modified:([^\n]*)", # fix empty LastModified
+    "updated_date": r"Last Modified:([^\n]*)",  # fix empty LastModified
 }
 
 ax = {

--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -34,6 +34,19 @@ ac_uk = {
     "name_servers": r"Servers:\s*(.+)\t\n\s*(.+)\t\n",
 }
 
+co_uk = {
+    "extend": "uk",
+    "domain_name": r"Domain name:\s+(.+)",
+    "registrar": r"Registrar:\s+(.+)",
+    "name_servers": r"Name servers:\s+(.+)\s+(.+)",
+    "status": r"Registration status:\s*(.+)",
+    "creation_date": r"Registered on:(.+)",
+    "expiration_date": r"Expiry date:(.+)",
+    "updated_date": r"Last updated:(.+)",
+    "owner": r"Domain Owner:\s+(.+)",
+    "registrant": r"Registered Contact:\s+(.+)",
+}
+
 # United Arab Emirates
 # ae = {    "extend": "ar"}
 # redefined below


### PR DESCRIPTION
do_parse:

- no functional changes just moving parts of code to their own functions to unclutter do_parse
- this prepares for the later handling of IANA domains like example.com and exmple.net which will introduce changed behaviour
- 

test2:

- changed test2 to show the variable type and highlight empty strings as return value when no data is present