### PR TITLE
create a test environment with static test data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ out
 reformat-code.sh
 t1.py
 typescript
+test.out

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ Raise an issue https://github.com/DannyCork/python-whois/issues/new
 2022-11-04: maarten_boot
  * add support for Iana example.com, example.net
 
+2022-11-07: maarten_boot
+ * add testing against static known data in dir: ./testdata/<domain>/output
+ * test.sh will test all domains in testdata without actually calling whois, the input data is instead read from testdata/<domain>/input
+
 ## Support
  * Python 3.x is supported.
  * Python 2.x IS NOT supported.

--- a/test.sh
+++ b/test.sh
@@ -19,7 +19,7 @@ testOneDomain()
     echo "testing: $domain"
     ./test2.py -d "$domain" >"$TestDataDir/$domain/test.out"
 
-    diff "$TestDataDir/$domain/output" "$TestDataDir/$domain/test.out"
+    diff "$TestDataDir/$domain/output" "$TestDataDir/$domain/test.out" | tee "$TestDataDir/$domain/out"
 }
 
 main()

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,34 @@
+#! /usr/bin/bash
+
+# signal whois module that we are testing, this reads data from testdata/<domain>/in
+export TEST_WHOIS_PYTHON="1"
+
+TestDataDir="./testdata"
+
+get_testdomains()
+{
+    ls "$TestDataDir" |
+    grep -v ".sh"
+}
+
+testOneDomain()
+{
+    domain="$1"
+    [ ! -d "$TestDataDir/$domain" ] && return
+
+    echo "testing: $domain"
+    ./test2.py -d "$domain" >"$TestDataDir/$domain/test.out"
+
+    diff "$TestDataDir/$domain/output" "$TestDataDir/$domain/test.out"
+}
+
+main()
+{
+    get_testdomains |
+    while read line
+    do
+        testOneDomain $(basename $line)
+    done
+}
+
+main

--- a/testdata/example.com/input
+++ b/testdata/example.com/input
@@ -1,0 +1,15 @@
+[Querying whois.verisign-grs.com]
+[Redirected to whois.iana.org]
+[Querying whois.iana.org]
+[whois.iana.org]
+% IANA WHOIS server
+% for more information on IANA, visit http://www.iana.org
+% This query returned 1 object
+
+domain:       EXAMPLE.COM
+
+organisation: Internet Assigned Numbers Authority
+
+created:      1992-01-01
+source:       IANA
+

--- a/testdata/example.com/output
+++ b/testdata/example.com/output
@@ -1,0 +1,15 @@
+## ===== TEST DOMAINS
+
+test domain: <<<<<<<<<< example.com >>>>>>>>>>>>>>>>>>>>
+name               str               'example.com'
+tld                str               'com'
+registrar          str               'Internet Assigned Numbers Authority'
+registrant_country str               ''
+creation_date      datetime.datetime 1992-01-01 00:00:00
+expiration_date    NoneType          None
+last_updated       NoneType          None
+status             str               ''
+statuses           list              ['']
+dnssec             bool              False
+name_servers       list              []
+registrant         str               ''

--- a/testdata/example.net/input
+++ b/testdata/example.net/input
@@ -1,0 +1,15 @@
+[Querying whois.verisign-grs.com]
+[Redirected to whois.iana.org]
+[Querying whois.iana.org]
+[whois.iana.org]
+% IANA WHOIS server
+% for more information on IANA, visit http://www.iana.org
+% This query returned 1 object
+
+domain:       EXAMPLE.NET
+
+organisation: Internet Assigned Numbers Authority
+
+created:      1992-01-01
+source:       IANA
+

--- a/testdata/example.net/output
+++ b/testdata/example.net/output
@@ -1,0 +1,15 @@
+## ===== TEST DOMAINS
+
+test domain: <<<<<<<<<< example.net >>>>>>>>>>>>>>>>>>>>
+name               str               'example.net'
+tld                str               'net'
+registrar          str               'Internet Assigned Numbers Authority'
+registrant_country str               ''
+creation_date      datetime.datetime 1992-01-01 00:00:00
+expiration_date    NoneType          None
+last_updated       NoneType          None
+status             str               ''
+statuses           list              ['']
+dnssec             bool              False
+name_servers       list              []
+registrant         str               ''

--- a/testdata/example.org/input
+++ b/testdata/example.org/input
@@ -1,0 +1,65 @@
+[Querying whois.pir.org]
+[whois.pir.org]
+Domain Name: example.org
+Registry Domain ID: 13a1800564ae4cf589c9f5723a630958-LROR
+Registrar WHOIS Server: 
+Registrar URL: 
+Updated Date: 2022-10-14T04:00:28Z
+Creation Date: 1995-08-31T04:00:00Z
+Registry Expiry Date: 2023-08-30T04:00:00Z
+Registrar: ICANN
+Registrar IANA ID: 376
+Registrar Abuse Contact Email: 
+Registrar Abuse Contact Phone: 
+Domain Status: serverDeleteProhibited https://icann.org/epp#serverDeleteProhibited
+Domain Status: serverRenewProhibited https://icann.org/epp#serverRenewProhibited
+Domain Status: serverTransferProhibited https://icann.org/epp#serverTransferProhibited
+Domain Status: serverUpdateProhibited https://icann.org/epp#serverUpdateProhibited
+Registry Registrant ID: REDACTED FOR PRIVACY
+Registrant Name: REDACTED FOR PRIVACY
+Registrant Organization: ICANN
+Registrant Street: REDACTED FOR PRIVACY
+Registrant City: REDACTED FOR PRIVACY
+Registrant State/Province: CA
+Registrant Postal Code: REDACTED FOR PRIVACY
+Registrant Country: US
+Registrant Phone: REDACTED FOR PRIVACY
+Registrant Phone Ext: REDACTED FOR PRIVACY
+Registrant Fax: REDACTED FOR PRIVACY
+Registrant Fax Ext: REDACTED FOR PRIVACY
+Registrant Email: Please query the RDDS service of the Registrar of Record identified in this output for information on how to contact the Registrant, Admin, or Tech contact of the queried domain name.
+Registry Admin ID: REDACTED FOR PRIVACY
+Admin Name: REDACTED FOR PRIVACY
+Admin Organization: REDACTED FOR PRIVACY
+Admin Street: REDACTED FOR PRIVACY
+Admin City: REDACTED FOR PRIVACY
+Admin State/Province: REDACTED FOR PRIVACY
+Admin Postal Code: REDACTED FOR PRIVACY
+Admin Country: REDACTED FOR PRIVACY
+Admin Phone: REDACTED FOR PRIVACY
+Admin Phone Ext: REDACTED FOR PRIVACY
+Admin Fax: REDACTED FOR PRIVACY
+Admin Fax Ext: REDACTED FOR PRIVACY
+Admin Email: Please query the RDDS service of the Registrar of Record identified in this output for information on how to contact the Registrant, Admin, or Tech contact of the queried domain name.
+Registry Tech ID: REDACTED FOR PRIVACY
+Tech Name: REDACTED FOR PRIVACY
+Tech Organization: REDACTED FOR PRIVACY
+Tech Street: REDACTED FOR PRIVACY
+Tech City: REDACTED FOR PRIVACY
+Tech State/Province: REDACTED FOR PRIVACY
+Tech Postal Code: REDACTED FOR PRIVACY
+Tech Country: REDACTED FOR PRIVACY
+Tech Phone: REDACTED FOR PRIVACY
+Tech Phone Ext: REDACTED FOR PRIVACY
+Tech Fax: REDACTED FOR PRIVACY
+Tech Fax Ext: REDACTED FOR PRIVACY
+Tech Email: Please query the RDDS service of the Registrar of Record identified in this output for information on how to contact the Registrant, Admin, or Tech contact of the queried domain name.
+Name Server: a.iana-servers.net
+Name Server: b.iana-servers.net
+DNSSEC: signedDelegation
+URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
+>>> Last update of WHOIS database: 2022-11-07T09:27:18Z <<<
+
+For more information on Whois status codes, please visit https://icann.org/epp
+
+Terms of Use: Access to Public Interest Registry WHOIS information is provided to assist persons in determining the contents of a domain name registration record in the Public Interest Registry registry database. The data in this record is provided by Public Interest Registry for informational purposes only, and Public Interest Registry does not guarantee its accuracy. This service is intended only for query-based access. You agree that you will use this data only for lawful purposes and that, under no circumstances will you use this data to (a) allow, enable, or otherwise support the transmission by e-mail, telephone, or facsimile of mass unsolicited, commercial advertising or solicitations to entities other than the data recipient's own existing customers; or (b) enable high volume, automated, electronic processes that send queries or data to the systems of Registry Operator, a Registrar, or Donuts except as reasonably necessary to register domain names or modify existing registrations. All rights reserved. Public Interest Registry reserves the right to modify these terms at any time. By submitting this query, you agree to abide by this policy.  The Registrar of Record identified in this output may have an RDDS service that can be queried for additional information on how to contact the Registrant, Admin, or Tech contact of the queried domain name.

--- a/testdata/example.org/output
+++ b/testdata/example.org/output
@@ -1,0 +1,15 @@
+## ===== TEST DOMAINS
+
+test domain: <<<<<<<<<< example.org >>>>>>>>>>>>>>>>>>>>
+name               str               'example.org'
+tld                str               'org'
+registrar          str               'ICANN'
+registrant_country str               'US'
+creation_date      datetime.datetime 1995-08-31 04:00:00
+expiration_date    datetime.datetime 2023-08-30 04:00:00
+last_updated       NoneType          None
+status             str               'serverDeleteProhibited https://icann.org/epp#serverDeleteProhibited'
+statuses           list              ['serverDeleteProhibited https://icann.org/epp#serverDeleteProhibited', 'serverRenewProhibited https://icann.org/epp#serverRenewProhibited', 'serverTransferProhibited https://icann.org/epp#serverTransferProhibited', 'serverUpdateProhibited https://icann.org/epp#serverUpdateProhibited']
+dnssec             bool              True
+name_servers       list              ['a.iana-servers.net', 'b.iana-servers.net']
+registrant         str               'ICANN'

--- a/testdata/make_testdata.sh
+++ b/testdata/make_testdata.sh
@@ -1,0 +1,22 @@
+#! /usr/bin/bash
+
+DOMAINS=(
+    example.net
+    example.com
+    example.org
+    meta.co.uk
+)
+
+for str in ${DOMAINS[@]}
+do
+    echo "$str"
+
+    # create one dir for each domain we will test
+    mkdir -p "$str"
+
+    # dump the raw whois data as in
+    whois "$str" | tee "./$str/input"
+
+    # dump the expected output as out
+    ../test2.py -d "$str" | tee "./$str/output"
+done

--- a/testdata/meta.co.uk/input
+++ b/testdata/meta.co.uk/input
@@ -1,0 +1,48 @@
+[Querying whois.nic.uk]
+[whois.nic.uk]
+
+    Domain name:
+        meta.co.uk
+
+    Registrant:
+        Meta Platforms, Inc.
+
+    Registrant type:
+        Non-UK Corporation
+
+    Data validation:
+        Nominet was not able to match the registrant's name and/or address against a 3rd party source on 28-Jul-2022
+
+    Registrar:
+        Hogan Lovells International LLP [Tag = LOVELLSLLP]
+        URL: https://www.anchovy.com
+
+    Relevant dates:
+        Registered on: 01-Nov-2001
+        Expiry date:  01-Nov-2029
+        Last updated:  28-Jul-2022
+
+    Registration status:
+        Registered until expiry date.
+
+    Name servers:
+        a.ns.facebook.com
+        b.ns.facebook.com
+        c.ns.facebook.com
+        d.ns.facebook.com
+
+    WHOIS lookup made at 09:27:19 07-Nov-2022
+
+-- 
+This WHOIS information is provided for free by Nominet UK the central registry
+for .uk domain names. This information and the .uk WHOIS are:
+
+    Copyright Nominet UK 1996 - 2022.
+
+You may not access the .uk WHOIS or use any data from it except as permitted
+by the terms of use available in full at https://www.nominet.uk/whoisterms,
+which includes restrictions on: (A) use of the data for advertising, or its
+repackaging, recompilation, redistribution or reuse (B) obscuring, removing
+or hiding any or all of this notice and (C) exceeding query rate or volume
+limits. The data is provided on an 'as-is' basis and may lag behind the
+register. Access may be withdrawn or restricted at any time. 

--- a/testdata/meta.co.uk/output
+++ b/testdata/meta.co.uk/output
@@ -1,0 +1,16 @@
+## ===== TEST DOMAINS
+
+test domain: <<<<<<<<<< meta.co.uk >>>>>>>>>>>>>>>>>>>>
+name               str               'meta.co.uk'
+tld                str               'co_uk'
+registrar          str               'Hogan Lovells International LLP [Tag = LOVELLSLLP]'
+registrant_country str               ''
+creation_date      datetime.datetime 2001-11-01 00:00:00
+expiration_date    datetime.datetime 2029-11-01 00:00:00
+last_updated       datetime.datetime 2022-07-28 00:00:00
+status             str               'Registered until expiry date.'
+statuses           list              ['Registered until expiry date.']
+dnssec             bool              False
+name_servers       list              ['a.ns.facebook.com', 'b.ns.facebook.com']
+owner              str               ''
+registrant         str               ''

--- a/whois/_3_adjust.py
+++ b/whois/_3_adjust.py
@@ -46,7 +46,13 @@ class Domain:
         self.last_updated = str_to_date(data["updated_date"][0], self.tld.lower())
 
         self.status = data["status"][0].strip()
-        self.statuses = list(set([s.strip() for s in data["status"]]))  # list(set(...))) to deduplicate
+        self.statuses = sorted(  # sorted added to get predictable output during test
+            list(  # list(set(...))) to deduplicate results
+                set(
+                    [s.strip() for s in data["status"]],
+                ),
+            ),
+        )
 
         self.dnssec = data["DNSSEC"]
 


### PR DESCRIPTION
Create static testing data to test against known input and known output.
Data is added to testdata/<domain>/ on running ./testdata/make_testdata.sh.
./test.sh will execute ./test2.py with env TEST_WHOIS_PYTHON set,
this will cause the whois command not to be used, static input data will be used instead so we have a predictable input and a static output against which we will compare the result of test2.py -d <domain>