### PR TITLE
add text to Domain result; but only if requested

### DIFF
--- a/test2.py
+++ b/test2.py
@@ -6,6 +6,8 @@ import getopt
 import sys
 
 Verbose = False
+PrintGetRawWhoisResult = False
+
 Failures = {}
 IgnoreReturncode = False
 
@@ -20,12 +22,15 @@ def xType(x):
     return s.split("'")[1]
 
 
-def testItem(d):
+def testItem(d: str, printgetRawWhoisResult: bool = False):
+    global PrintGetRawWhoisResult
+
     w = whois.query(
         d,
         ignore_returncode=IgnoreReturncode,
         verbose=Verbose,
         internationalized=True,
+        include_raw_whois_text=PrintGetRawWhoisResult,
     )
 
     if w is None:
@@ -174,6 +179,8 @@ test.py
         # files are processed as in the -f option so comments and empty lines are skipped
         # the option can be repeated to specify more then one directory
 
+    [ -p | --print also print text containing the raw output of whois ]
+
     # options are exclusive and without any options the test2 program does nothing
 
     # test one specific file with verbose and IgnoreReturncode
@@ -214,12 +221,14 @@ def showFailures():
 def main(argv):
     global Verbose
     global IgnoreReturncode
+    global PrintGetRawWhoisResult
 
     try:
         opts, args = getopt.getopt(
             argv,
-            "vIhaf:d:D:r:H:",
+            "pvIhaf:d:D:r:H:",
             [
+                "print",
                 "verbose",
                 "IgnoreReturncode",
                 "all",
@@ -267,6 +276,9 @@ def main(argv):
 
         if opt in ("-v", "--verbose"):
             Verbose = True
+
+        if opt in ("-p", "--print"):
+            PrintGetRawWhoisResult = True
 
         if opt in ("-D", "--Directory"):
             directory = arg
@@ -325,7 +337,6 @@ def main(argv):
         return
 
     if len(domains):
-        print("## ===== TEST DOMAINS")
         testDomains(domains)
         showFailures()
         return

--- a/testdata/example.com/output
+++ b/testdata/example.com/output
@@ -1,4 +1,3 @@
-## ===== TEST DOMAINS
 
 test domain: <<<<<<<<<< example.com >>>>>>>>>>>>>>>>>>>>
 name               str               'example.com'

--- a/testdata/example.net/output
+++ b/testdata/example.net/output
@@ -1,4 +1,3 @@
-## ===== TEST DOMAINS
 
 test domain: <<<<<<<<<< example.net >>>>>>>>>>>>>>>>>>>>
 name               str               'example.net'

--- a/testdata/example.org/input
+++ b/testdata/example.org/input
@@ -58,7 +58,7 @@ Name Server: a.iana-servers.net
 Name Server: b.iana-servers.net
 DNSSEC: signedDelegation
 URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
->>> Last update of WHOIS database: 2022-11-07T09:27:18Z <<<
+>>> Last update of WHOIS database: 2022-11-07T21:05:05Z <<<
 
 For more information on Whois status codes, please visit https://icann.org/epp
 

--- a/testdata/example.org/output
+++ b/testdata/example.org/output
@@ -1,4 +1,3 @@
-## ===== TEST DOMAINS
 
 test domain: <<<<<<<<<< example.org >>>>>>>>>>>>>>>>>>>>
 name               str               'example.org'

--- a/testdata/make_testdata.sh
+++ b/testdata/make_testdata.sh
@@ -1,10 +1,11 @@
 #! /usr/bin/bash
 
 DOMAINS=(
-    example.net
-    example.com
-    example.org
-    meta.co.uk
+    example.net # has iana source
+    example.com # has iana source
+    example.org # has no iana source
+    meta.co.uk # has multiline for all relevant fields and 4 nameservers; should be fixed output has only 2
+    # xs4all.nl # has multiline nameserver and multiline registrar; outout has no nameservers should be 2
 )
 
 for str in ${DOMAINS[@]}

--- a/testdata/meta.co.uk/input
+++ b/testdata/meta.co.uk/input
@@ -31,7 +31,7 @@
         c.ns.facebook.com
         d.ns.facebook.com
 
-    WHOIS lookup made at 09:27:19 07-Nov-2022
+    WHOIS lookup made at 21:05:06 07-Nov-2022
 
 -- 
 This WHOIS information is provided for free by Nominet UK the central registry

--- a/testdata/meta.co.uk/output
+++ b/testdata/meta.co.uk/output
@@ -1,4 +1,3 @@
-## ===== TEST DOMAINS
 
 test domain: <<<<<<<<<< meta.co.uk >>>>>>>>>>>>>>>>>>>>
 name               str               'meta.co.uk'

--- a/whois/_3_adjust.py
+++ b/whois/_3_adjust.py
@@ -33,8 +33,13 @@ class Domain:
     def __init__(
         self,
         data: Dict[str, Any],
+        whois_str: Optional[str] = None,
         verbose: bool = False,
+        include_raw_whois_text: bool = False,
     ):
+        if include_raw_whois_text and whois_str is not None:
+            self.text = whois_str
+
         self.name = data["domain_name"][0].strip().lower()
         self.tld = data["tld"]
 

--- a/whois/__init__.py
+++ b/whois/__init__.py
@@ -195,6 +195,7 @@ def query(
     verbose: bool = False,
     with_cleanup_results=False,
     internationalized: bool = False,
+    include_raw_whois_text: bool = False,
 ) -> Optional[Domain]:
     """
     force=True          Don't use cache.
@@ -285,7 +286,9 @@ def query(
         if pd and pd["domain_name"][0]:
             return Domain(
                 pd,
+                whois_str=q,
                 verbose=verbose,
+                include_raw_whois_text=include_raw_whois_text,
             )
 
         if len(d) > (len(tldLevel) + 1):


### PR DESCRIPTION
passing the flag include_raw_whois_text=True will add a extra "text" field to Domain and __dict__
the default is False so the default behavior is unchanged

w = whois.query("google.com")
print(w.__dict__)
{'name': 'google.com', 'tld': 'com', 'registrar': 'MarkMonitor, Inc.', 'registrant_country': 'US', 'creation_date': datetime.datetime(1997, 9, 15, 9, 0), 'expiration_date': None, 'last_updated': datetime.datetime(2019, 9, 9, 17, 39, 4), 'status': 'clientUpdateProhibited (https://www.icann.org/epp#clientUpdateProhibited)', 'statuses': ['clientDeleteProhibited (https://www.icann.org/epp#clientDeleteProhibited)', 'clientTransferProhibited (https://www.icann.org/epp#clientTransferProhibited)', 'clientUpdateProhibited (https://www.icann.org/epp#clientUpdateProhibited)', 'serverDeleteProhibited (https://www.icann.org/epp#serverDeleteProhibited)', 'serverTransferProhibited (https://www.icann.org/epp#serverTransferProhibited)', 'serverUpdateProhibited (https://www.icann.org/epp#serverUpdateProhibited)'], 'dnssec': False, 'name_servers': ['ns1.google.com', 'ns2.google.com', 'ns3.google.com', 'ns4.google.com'], 'registrant': 'Google LLC'}


w = whois.query("google.com",include_raw_whois_text=True)
print(w.__dict__)
{'text': '[Querying whois.verisign-grs.com]\n[Redirected to whois.markmonitor.com]\n[Querying whois.markmonitor.com]\n[whois.markmonitor.com]\nDomain Name: google.com\nRegistry Domain ID: 2138514_DOMAIN_COM-VRSN\nRegistrar WHOIS Server: whois.markmonitor.com\nRegistrar URL: http://www.markmonitor.com\nUpdated Date: 2019-09-09T15:39:04+0000\nCreation Date: 1997-09-15T07:00:00+0000\nRegistrar Registration Expiration Date: 2028-09-13T07:00:00+0000\nRegistrar: MarkMonitor, Inc.\nRegistrar IANA ID: 292\nRegistrar Abuse Contact Email: abusecomplaints@markmonitor.com\nRegistrar Abuse Contact Phone: +1.2086851750\nDomain Status: clientUpdateProhibited (https://www.icann.org/epp#clientUpdateProhibited)\nDomain Status: clientTransferProhibited (https://www.icann.org/epp#clientTransferProhibited)\nDomain Status: clientDeleteProhibited (https://www.icann.org/epp#clientDeleteProhibited)\nDomain Status: serverUpdateProhibited (https://www.icann.org/epp#serverUpdateProhibited)\nDomain Status: serverTransferProhibited (https://www.icann.org/epp#serverTransferProhibited)\nDomain Status: serverDeleteProhibited (https://www.icann.org/epp#serverDeleteProhibited)\nRegistrant Organization: Google LLC\nRegistrant State/Province: CA\nRegistrant Country: US\nRegistrant Email: Select Request Email Form at https://domains.markmonitor.com/whois/google.com\nAdmin Organization: Google LLC\nAdmin State/Province: CA\nAdmin Country: US\nAdmin Email: Select Request Email Form at https://domains.markmonitor.com/whois/google.com\nTech Organization: Google LLC\nTech State/Province: CA\nTech Country: US\nTech Email: Select Request Email Form at https://domains.markmonitor.com/whois/google.com\nName Server: ns1.google.com\nName Server: ns2.google.com\nName Server: ns4.google.com\nName Server: ns3.google.com\nDNSSEC: unsigned\nURL of the ICANN WHOIS Data Problem Reporting System: http://wdprs.internic.net/\n>>> Last update of WHOIS database: 2022-11-07T21:09:40+0000 <<<\n\nFor more information on WHOIS status codes, please visit:\n  https://www.icann.org/resources/pages/epp-status-codes\n\nIf you wish to contact this domain’s Registrant, Administrative, or Technical\ncontact, and such email address is not visible above, you may do so via our web\nform, pursuant to ICANN’s Temporary Specification. To verify that you are not a\nrobot, please enter your email address to receive a link to a page that\nfacilitates email communication with the relevant contact(s).\n\nWeb-based WHOIS:\n  https://domains.markmonitor.com/whois\n\nIf you have a legitimate interest in viewing the non-public WHOIS details, send\nyour request and the reasons for your request to whoisrequest@markmonitor.com\nand specify the domain name in the subject line. We will review that request and\nmay ask for supporting documentation and explanation.\n\nThe data in MarkMonitor’s WHOIS database is provided for information purposes,\nand to assist persons in obtaining information about or related to a domain\nname’s registration record. While MarkMonitor believes the data to be accurate,\nthe data is provided "as is" with no guarantee or warranties regarding its\naccuracy.\n\nBy submitting a WHOIS query, you agree that you will use this data only for\nlawful purposes and that, under no circumstances will you use this data to:\n  (1) allow, enable, or otherwise support the transmission by email, telephone,\nor facsimile of mass, unsolicited, commercial advertising, or spam; or\n  (2) enable high volume, automated, or electronic processes that send queries,\ndata, or email to MarkMonitor (or its systems) or the domain name contacts (or\nits systems).\n\nMarkMonitor reserves the right to modify these terms at any time.\n\nBy submitting this query, you agree to abide by this policy.\n\nMarkMonitor Domain Management(TM)\nProtecting companies and consumers in a digital world.\n\nVisit MarkMonitor at https://www.markmonitor.com\nContact us at +1.8007459229\nIn Europe, at +44.02032062220\n--\n', 'name': 'google.com', 'tld': 'com', 'registrar': 'MarkMonitor, Inc.', 'registrant_country': 'US', 'creation_date': datetime.datetime(1997, 9, 15, 9, 0), 'expiration_date': None, 'last_updated': datetime.datetime(2019, 9, 9, 17, 39, 4), 'status': 'clientUpdateProhibited (https://www.icann.org/epp#clientUpdateProhibited)', 'statuses': ['clientDeleteProhibited (https://www.icann.org/epp#clientDeleteProhibited)', 'clientTransferProhibited (https://www.icann.org/epp#clientTransferProhibited)', 'clientUpdateProhibited (https://www.icann.org/epp#clientUpdateProhibited)', 'serverDeleteProhibited (https://www.icann.org/epp#serverDeleteProhibited)', 'serverTransferProhibited (https://www.icann.org/epp#serverTransferProhibited)', 'serverUpdateProhibited (https://www.icann.org/epp#serverUpdateProhibited)'], 'dnssec': False, 'name_servers': ['ns1.google.com', 'ns2.google.com', 'ns3.google.com', 'ns4.google.com'], 'registrant': 'Google LLC'}
>>> 
