### PR TITLE
Refactor and add getting the raw whois data also for unsupported tld's 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ reformat-code.sh
 t1.py
 typescript
 test.out
+tmp/

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Raise an issue https://github.com/DannyCork/python-whois/issues/new
  * add testing against static known data in dir: ./testdata/<domain>/output
  * test.sh will test all domains in testdata without actually calling whois, the input data is instead read from testdata/<domain>/input
 
+2022-11-11: maarten_boot
+ * add support for returning the raw data from the whois command: flag include_raw_whois_text
+ * add support for handling unsupported domains via whois raw text only: flag return_raw_text_for_unsupported_tld
+
 ## Support
  * Python 3.x is supported.
  * Python 2.x IS NOT supported.

--- a/makeTestdataAll.sh
+++ b/makeTestdataAll.sh
@@ -1,0 +1,104 @@
+#! /bin/bash
+
+TMPDIR="./tmp"
+FORCE=0
+VERBOSE=1
+
+prepTempDir()
+{
+    mkdir -p "$TMPDIR" || {
+        echo "FATAL: cannot make test dir: $TMPDIR" >&2
+        exit 101
+    }
+}
+
+getAllTldSupported()
+{
+    ./test2.py -S
+}
+
+makeTestDataOriginalOne()
+{
+    local tld="$1"
+    local domain="$2"
+
+    local d="$TMPDIR/$tld"
+    mkdir -p "$d" || {
+        echo "FATAL: cannot make tld directory: '$d'" >&2
+        exit 101
+    }
+
+    local zz="$domain.$tld"
+
+    host -t soa "$zz" |
+    tee "$d/__dns-soa" |
+    grep " has SOA record " || {
+        # no soa record so that domain does not exist, cleanup the test dir
+        rm -f "$d/input" "$d/output" "$d/__domain__$zz" "$d/__dns-soa" "$d/dns-ns"
+        echo "INFO: no domain for $zz" >&2
+        return 1
+    }
+
+    host -t ns "$zz" > "$d/__dns-ns"
+
+    # what domain did we test
+    touch "$d/__domain__$zz"
+
+    # force english, force no cache
+    [ ! -s "$d/input" -o "$FORCE" = "1" ] && {
+        LANG=EN whois --force-lookup "meta.$tld" >"$d/input" || {
+            # whois has a problem
+            rm -f "$d/input" "$d/output" "$d/__domain__$zz" "$d/__dns-soa" "$d/dns-ns"
+            return 1
+        }
+    }
+
+    [ ! -s "$d/output" -o "$FORCE" = "1" ] && {
+        ./test2.py -d "meta.$tld" >"$d/output"
+    }
+
+    return 0
+}
+
+domainsToTry()
+{
+    cat <<! |
+meta
+google
+!
+    awk  '
+    /^[ \t]*$/ { next }
+    /^[ \t]*;/ { next }
+    /^[ \t]*#/ { next }
+    { print $1 }
+    '
+}
+
+makeTestDataOriginalAll()
+{
+    getAllTldSupported |
+    while read tld
+    do
+        echo "try: $tld"
+
+        domainsToTry |
+        while read domain
+        do
+            makeTestDataOriginalOne "$tld" "$domain"
+            [ -f "$TMPDIR/$tld/input" ] && {
+                [ "$VERBOSE" ] && {
+                    ls -l "$TMPDIR/$tld/"
+                }
+                break
+            }
+        done
+    done
+}
+
+main()
+{
+    prepTempDir
+    makeTestDataOriginalAll
+}
+
+main

--- a/test.sh
+++ b/test.sh
@@ -1,8 +1,12 @@
 #! /usr/bin/bash
 
 # signal whois module that we are testing, this reads data from testdata/<domain>/in
-TestDataDir=$(realpath ./testdata)
-export TEST_WHOIS_PYTHON="$TestDataDir"
+prepPath()
+{
+    local xpath="$1"
+    TestDataDir=$( realpath "$xpath" )
+    export TEST_WHOIS_PYTHON="$TestDataDir"
+}
 
 get_testdomains()
 {
@@ -23,6 +27,11 @@ testOneDomain()
 
 main()
 {
+    prepPath "testdata" # set a default
+    [ -d "$1" ] && { # if a argument and is a dir use that for testing
+        prepPath "$1"
+    }
+
     get_testdomains |
     while read line
     do
@@ -30,4 +39,4 @@ main()
     done
 }
 
-main
+main $*

--- a/test.sh
+++ b/test.sh
@@ -1,9 +1,8 @@
 #! /usr/bin/bash
 
 # signal whois module that we are testing, this reads data from testdata/<domain>/in
-export TEST_WHOIS_PYTHON="1"
-
-TestDataDir="./testdata"
+TestDataDir=$(realpath ./testdata)
+export TEST_WHOIS_PYTHON="$TestDataDir"
 
 get_testdomains()
 {

--- a/test2.py
+++ b/test2.py
@@ -260,7 +260,7 @@ def main(argv):
     fileData = {}
 
     for opt, arg in opts:
-        if opt in ( "-S", "SupportedTld"):
+        if opt in ("-S", "SupportedTld"):
             for tld in sorted(whois.validTlds()):
                 print(tld)
             sys.exit(0)

--- a/test2.py
+++ b/test2.py
@@ -226,8 +226,9 @@ def main(argv):
     try:
         opts, args = getopt.getopt(
             argv,
-            "pvIhaf:d:D:r:H:",
+            "SpvIhaf:d:D:r:H:",
             [
+                "SupportedTld",
                 "print",
                 "verbose",
                 "IgnoreReturncode",
@@ -259,9 +260,14 @@ def main(argv):
     fileData = {}
 
     for opt, arg in opts:
+        if opt in ( "-S", "SupportedTld"):
+            for tld in sorted(whois.validTlds()):
+                print(tld)
+            sys.exit(0)
+
         if opt == "-h":
             usage()
-            sys.exit()
+            sys.exit(0)
 
         if opt in ("-a", "--all"):
             testAllTld = True

--- a/whois/_1_query.py
+++ b/whois/_1_query.py
@@ -123,8 +123,9 @@ def testWhoisPythonFromStaticTestData(
 
     pathToTestFile = f"./testdata/{domain}/input"
     if os.path.exists(pathToTestFile):
-        with open(pathToTestFile, mode="r") as f:
-            return f.read()
+        with open(pathToTestFile, mode="rb") as f:  # switch to binary mode as that is what Popen uses
+            # make sure the data is treated exactly the same as the output of Popen
+            return f.read().decode(errors="ignore")
 
     raise WhoisCommandFailed("")
 
@@ -135,7 +136,7 @@ def _do_whois_query(
     server: Optional[str] = None,
     verbose: bool = False,
 ) -> str:
-    # TODO: if getenv[TEST_WHOIS_PYTON] fake whois by reading static data from a file
+    # if getenv[TEST_WHOIS_PYTON] fake whois by reading static data from a file
     # this wasy we can actually implemnt a test run with known data in and expected data out
     if os.getenv("TEST_WHOIS_PYTHON"):
         return testWhoisPythonFromStaticTestData(dl, ignore_returncode, server, verbose)
@@ -150,7 +151,6 @@ def _do_whois_query(
         env={"LANG": "en"} if dl[-1] in ".jp" else None,
     )
 
-    # print(p.stdout.read()+' '+p.stderr.read())
     r = p.communicate()[0].decode(errors="ignore")
     if ignore_returncode is False and p.returncode not in [0, 1]:
         raise WhoisCommandFailed(r)

--- a/whois/_1_query.py
+++ b/whois/_1_query.py
@@ -120,8 +120,8 @@ def testWhoisPythonFromStaticTestData(
     verbose: bool = False,
 ) -> str:
     domain = ".".join(dl)
-
-    pathToTestFile = f"./testdata/{domain}/input"
+    testDir = os.getenv("TEST_WHOIS_PYTHON")
+    pathToTestFile = f"{testDir}/{domain}/input"
     if os.path.exists(pathToTestFile):
         with open(pathToTestFile, mode="rb") as f:  # switch to binary mode as that is what Popen uses
             # make sure the data is treated exactly the same as the output of Popen

--- a/whois/_3_adjust.py
+++ b/whois/_3_adjust.py
@@ -36,9 +36,15 @@ class Domain:
         whois_str: Optional[str] = None,
         verbose: bool = False,
         include_raw_whois_text: bool = False,
+        return_raw_text_for_unsupported_tld: bool = False,
     ):
         if include_raw_whois_text and whois_str is not None:
             self.text = whois_str
+
+        if return_raw_text_for_unsupported_tld is True:
+            self.tld = data["tld"]
+            self.name = data["domain_name"][0].strip().lower()
+            return
 
         self.name = data["domain_name"][0].strip().lower()
         self.tld = data["tld"]

--- a/whois/__init__.py
+++ b/whois/__init__.py
@@ -274,7 +274,7 @@ def query(
 
     assert isinstance(domain, str), Exception("`domain` - must be <str>")
 
-    tld, d = fromDomainStringToTld(domain, internationalized, verbose)
+    tld, dl = fromDomainStringToTld(domain, internationalized, verbose)
     if tld is None:
         return None
 
@@ -291,10 +291,10 @@ def query(
     # but if the tld is yyy.zzz we should only try xxx.yyy.zzz
 
     cache_file = cache_file or CACHE_FILE
-    tldLevel = tld.split("_")
+    tldLevel = tld.split("_")  # note while the top level domain may have a . the tld has a _ ( co.uk becomes co_uk )
     while 1:
-        q = do_query(
-            dl=d,
+        whois_str = do_query(
+            dl=dl,
             force=force,
             cache_file=cache_file,
             slow_down=slow_down,
@@ -303,27 +303,27 @@ def query(
             verbose=verbose,
         )
 
-        pd = do_parse(
-            whois_str=q,
+        data = do_parse(
+            whois_str=whois_str,
             tld=tld,
-            dl=d,
+            dl=dl,
             verbose=verbose,
             with_cleanup_results=with_cleanup_results,
         )
 
         # do we have a result and does it have a domain name
-        if pd and pd["domain_name"][0]:
+        if data and data["domain_name"][0]:
             return Domain(
-                pd,
-                whois_str=q,
+                data=data,
+                whois_str=whois_str,
                 verbose=verbose,
                 include_raw_whois_text=include_raw_whois_text,
             )
 
-        if len(d) > (len(tldLevel) + 1):
-            d = d[1:]  # strip one element from the front and try again
+        if len(dl) > (len(tldLevel) + 1):
+            dl = dl[1:]  # strip one element from the front and try again
             if verbose:
-                print(f"try again with {d}, {len(d)}, {len(tldLevel) + 1}", file=sys.stderr)
+                print(f"try again with {dl}, {len(dl)}, {len(tldLevel) + 1}", file=sys.stderr)
             continue
 
         # no result or no domain but we can not reduce any further so we have None


### PR DESCRIPTION
use the same type of file reading on Popen and the testFile
rename variables in __init__ query: d -> dl, pd -> data, q -> whois_str, so the function args are the same as are all others already
split of the beginning of query into clearly named functions to increase readability of the steps done