### PR TITLE
Fix for Windows, list of test with 'None' result, server for AI TLD

### DIFF
--- a/test.py
+++ b/test.py
@@ -15,6 +15,7 @@ NEW_TESTS = """
     # OK NOW:
     # abroco.me
     # wp.pl
+    # google.ai
 
     # New TLD
     whois.aero

--- a/test.py
+++ b/test.py
@@ -353,7 +353,7 @@ DOMAINS = """
 """
 
 failure = {}
-
+nones = []
 
 def prepItem(d):
     print("-" * 80)
@@ -367,6 +367,7 @@ def testItem(d):
         for k, v in wd.items():
             print('%20s\t"%s"' % (k, v))
     else:
+        nones.append(d)
         print("None")
 
 
@@ -451,11 +452,14 @@ def main():
         print("\n========================================\n")
         testDomains(UnknownDateFormat.split("\n"))
 
-        print(f"Failure during test : {len(failure)}")
-
     print("\n# ========================")
+    print(f"Failure during test : {len(failure)}")
     for i in sorted(failure.keys()):
         print(i, failure[i])
 
+    print("\n# ========================")
+    print(f"Domains with 'None' result : {len(nones)}")
+    for d in sorted(nones):
+        print(d)
 
 main()

--- a/whois/_1_query.py
+++ b/whois/_1_query.py
@@ -104,9 +104,25 @@ def makeWhoisCommandToRun(
 
     if platform.system() == "Windows":
         # Usage: whois [-v] domainname [whois.server]
-        if not os.path.exists("whois.exe"):
-            tryInstallMissingWhoisOnWindows(verbose)
-        wh = r".\whois.exe "
+
+        if os.path.exists("whois.exe"):
+            wh = r".\whois.exe "
+        else:
+            find = False
+            paths = os.environ["path"].split(";")
+            for path in paths:
+                wpath = os.path.join(path, "whois.exe")
+                if os.path.exists(wpath):
+                    wh = wpath
+                    find = True
+                    break
+
+            if not find:
+                tryInstallMissingWhoisOnWindows(verbose)
+
+        if server:
+            return [wh, "-v", "-nobanner", domain, server]
+        return [wh, "-v", "-nobanner", domain]
 
     if server:
         return [wh, domain, "-h", server]

--- a/whois/_2_parse.py
+++ b/whois/_2_parse.py
@@ -80,7 +80,7 @@ def cleanupWhoisResponse(
         if line.startswith("Terms of Use:"):  # these lines contibute nothing so ignore
             continue
 
-        tmp2.append(line)
+        tmp2.append(line.strip("\r"))
 
     return "\n".join(tmp2)
 

--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -54,6 +54,7 @@ co_uk = {
 # Anguilla
 ai = {
     "extend": "com",
+    "_server": "whois.nic.ai",
 }
 
 # Armenia


### PR DESCRIPTION
Suppress \r from response lines
Search whois.exe in all path contained in PATH environment variable

'None' responses may indicate the need to query a different whois server

Set _server to whois.nic.ai, which returns details instead of 'None'
