### PR TITLE
Fix regexp in ac tld

### DIFF
--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -1476,7 +1476,7 @@ ac = {
     "registrant_country": None,
     "updated_date": r"Updated Date:\s+(.+)",
     "creation_date": r"Creation Date:\s+(.+)",
-    "expiration_date": r":Registry Expiry Date\s+(.+)",
+    "expiration_date": r"Registry Expiry Date:\s+(.+)",
 }
 
 ae = {


### PR DESCRIPTION
My whois requests to .design TLD has no "expiration_date". After check tld regexp, I found a mistake in "ac" regexp, which the .design tld uses.
Normal whois output looks like: 

`Registry Expiry Date: 2025-02-17T23:59:59Z`

