### PR TITLE
validate nameservers against dns output,  fix discrepancies where possible

### DIFF
--- a/test3.py
+++ b/test3.py
@@ -1,0 +1,400 @@
+#!/usr/bin/python3
+import whois
+import os
+import re
+import getopt
+import sys
+import subprocess
+from typing import Optional, List, Dict
+
+Verbose = False
+PrintGetRawWhoisResult = False
+Ruleset = False
+
+Failures = {}
+IgnoreReturncode = False
+
+
+class ResponseCleaner:
+    data: Optional[str] = None
+    rDict: Dict = {}
+
+    def __init__(self, pathToTestFile: str):
+        self.data = self.readInputFile(pathToTestFile)
+
+    def readInputFile(self, pathToTestFile: str):
+        if not os.path.exists(pathToTestFile):
+            return None
+
+        with open(pathToTestFile, mode="rb") as f:  # switch to binary mode as that is what Popen uses
+            # make sure the data is treated exactly the same as the output of Popen
+            return f.read().decode(errors="ignore")
+
+    def cleanSection(self, section: List) -> List:
+        # cleanup any beginning and ending empty lines from the section
+
+        if len(section) == 0:
+            return section
+
+        rr = r"^\s*$"
+        n = 0  # remove empty lines from the start of section
+        while re.match(rr, section[n]):
+            section.pop(n)
+            # n stays 0
+
+        n = len(section) - 1  # remove empty lines from the end of the section
+        while re.match(rr, section[n]):
+            section.pop(n)
+            n = len(section) - 1  # remove empty lines from the end of section
+
+        return section
+
+    def splitBodyInSections(self, body: List) -> List:
+        # split the body on empty line, cleanup all sections, remove empty sections
+        # return list of body's
+
+        sections = []
+        n = 0
+        sections.append([])
+        for line in body:
+            if re.match(r"^\s*$", line):
+                n += 1
+                sections.append([])
+                continue
+            sections[n].append(line)
+
+        m = 0
+        while m < len(sections):
+            sections[m] = self.cleanSection(sections[m])
+            m += 1
+
+        # now remove ampty sections and return
+        sections2 = []
+        m = 0
+        while m < len(sections):
+            if len(sections[m]) > 0:
+                sections2.append("\n".join(sections[m]))
+            m += 1
+
+        return sections2
+
+    def cleanupWhoisResponse(
+        self,
+        verbose: bool = False,
+        with_cleanup_results: bool = False,
+    ):
+        result = whois._2_parse.cleanupWhoisResponse(
+            self.data,
+            verbose=False,
+            with_cleanup_results=False,
+        )
+
+        self.rDict = {
+            "BodyHasSections": False,  # if this is true the body is not a list of lines but a list of sections with lines
+            "Preamble": [],  # the lines telling what whois servers wwere contacted
+            "Percent": [],  # lines staring with %% , often not present but may contain hints
+            "Body": [],  # the body of the whois, may be in sections separated by empty lines
+            "Postamble": [],  # copyright and other not relevant info for actual parsing whois
+        }
+        body = []
+
+        rr = []
+        z = result.split("\n")
+        preambleSeen = False
+        postambleSeen = False
+        percentSeen = False
+        for line in z:
+            if preambleSeen is False:
+                if line.startswith("["):
+                    self.rDict["Preamble"].append(line)
+                    line = "PRE;" + line
+                    continue
+                else:
+                    preambleSeen = True
+
+            if preambleSeen is True and percentSeen is False:
+                if line.startswith("%"):
+                    self.rDict["Percent"].append(line)
+                    line = "PERCENT;" + line
+                    continue
+                else:
+                    percentSeen = True
+
+            if postambleSeen is False:
+                if line.startswith("-- ") or line.startswith(">>> ") or line.startswith("Copyright notice"):
+                    postambleSeen = True
+
+            if postambleSeen is True:
+                self.rDict["Postamble"].append(line)
+                line = "POST;" + line
+                continue
+
+            body.append(line)
+
+            if "\t" in line:
+                line = "TAB;" + line  # mark lines having tabs
+
+            if line.endswith("\r"):
+                line = "CR;" + line  # mark lines having CR (\r)
+
+            rr.append(line)
+
+        body = self.cleanSection(body)
+        self.rDict["Body"] = self.splitBodyInSections(body)
+        return "\n".join(rr), self.rDict
+
+    def printMe(self):
+        zz = ["Preamble", "Percent", "Postamble"]
+        for k in zz:
+            n = 0
+            for lines in self.rDict[k]:
+                tab = " [TAB] " if "\t" in lines else ""  # tabs are present in this section
+                cr = " [CR] " if "\r" in lines else ""  # \r is present in this section
+                print(k, cr, tab, lines)
+
+        k = "Body"
+        if len(self.rDict[k]):
+            n = 0
+            for lines in self.rDict[k]:
+                ws = " [WHITESPACE AT END] " if re.search(r"[ \t]+\r?\n", lines) else ""
+                tab = " [TAB] " if "\t" in lines else ""  # tabs are present in this section
+                cr = " [CR] " if "\r" in lines else ""  # \r is present in this section
+                print(f"# --- {k} Section: {n} {cr}{tab}{ws}")
+                n += 1
+                print(lines)
+
+
+def prepItem(d):
+    print("")
+    print(f"test domain: <<<<<<<<<< {d} >>>>>>>>>>>>>>>>>>>>")
+
+
+def xType(x):
+    s = f"{type(x)}"
+    return s.split("'")[1]
+
+
+def doDnsDomainExists(domain):
+
+    cmd = ["host", "-t", "ns", domain]
+
+    # LANG=en is added to make the ".jp" output consist across all environments
+    p = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        env={"LANG": "en"},
+    )
+
+    r = p.communicate()[0].decode(errors="ignore")
+    what = r.split("\n")
+
+    rr = []
+    for i in what:
+        if " name server " in i:
+            rr.append(i.split(" ")[-1].lower())
+    return rr
+
+
+def testItem(d: str, printgetRawWhoisResult: bool = False):
+    global PrintGetRawWhoisResult
+
+    w = whois.query(
+        d,
+        ignore_returncode=IgnoreReturncode,
+        verbose=Verbose,
+        internationalized=True,
+        include_raw_whois_text=PrintGetRawWhoisResult,
+    )
+    return w
+
+    if w is None:
+        print("None")
+        return
+
+    # the 3 date time items can be None if not present or a datetime string
+    # dnssec is a bool
+    # some strings are return as '' when empty (status)
+    # statuses can be a array of one empty string if no data
+
+    # not all values are always present it mainly depends on whet we see in the output of whois
+    # if we return not None: the elements that ars always there ars domain_name , tld, dnssec
+
+    wd = w.__dict__
+    for k, v in wd.items():
+        ss = "%-18s %-17s "
+        if isinstance(v, str):
+            print((ss + "'%s'") % (k, xType(v), v))
+        else:
+            print((ss + "%s") % (k, xType(v), v))
+
+
+def errorItem(d, e, what="Generic"):
+    if what not in Failures:
+        Failures[what] = {}
+    Failures[what][d] = e
+
+    message = f"Domain: {d}; Exception: {what}; Error: {e}"
+    print(message)
+
+
+def testDomains(aList):
+    for d in aList:
+
+        # skip empty lines
+        if not d:
+            continue
+
+        if len(d.strip()) == 0:
+            continue
+
+        # skip comments
+        if d.strip().startswith("#"):
+            continue
+
+        # skip comments behind the domain
+        d = d.split("#")[0]
+        d = d.strip()
+
+        ns = sorted(doDnsDomainExists(d))
+        if len(ns) == 0:
+            continue
+
+        # prepItem(d)
+        try:
+            w = testItem(d)
+            if w is None:
+                print("None")
+                continue
+
+            wd = w.__dict__
+            for k, v in wd.items():
+                if k == "name_servers":
+                    if len(v) != len(ns):
+                        ss = "%-18s %-17s "
+                        if not isinstance(v, str):
+                            print(d, (ss + "%s") % (k, xType(v), v))
+                            print(ns)
+
+        except whois.UnknownTld as e:
+            errorItem(d, e, what="UnknownTld")
+        except whois.FailedParsingWhoisOutput as e:
+            errorItem(d, e, what="FailedParsingWhoisOutput")
+        except whois.UnknownDateFormat as e:
+            errorItem(d, e, what="UnknownDateFormat")
+        except whois.WhoisCommandFailed as e:
+            errorItem(d, e, what="WhoisCommandFailed")
+        except whois.WhoisQuotaExceeded as e:
+            errorItem(d, e, what="WhoisQuotaExceeded")
+        except whois.WhoisPrivateRegistry as e:
+            errorItem(d, e, what="WhoisPrivateRegistry")
+
+
+def getTestFileOne(fPath, fileData):
+    if not os.path.isfile(fPath):  # only files
+        return
+
+    if not fPath.endswith(".txt"):  # ending in .txt
+        return
+
+    bName = fPath[:-4]
+    fileData[bName] = []
+    xx = fileData[bName]
+
+    with open(fPath) as f:
+        for index, line in enumerate(f):
+            line = line.strip()
+            if len(line) == 0 or line.startswith("#"):
+                continue
+
+            aa = re.split(r"\s+", line)
+            if aa[0] not in xx:
+                xx.append(aa[0])
+
+    return
+
+
+def getTestFilesAll(tDir, fileData):
+    for item in os.listdir(tDir):
+        fPath = f"{tDir}/{item}"
+        getTestFileOne(fPath, fileData)
+
+
+def getAllCurrentTld():
+    return whois.validTlds()
+
+
+def makeMetaAllCurrentTld(allHaving=None, allRegex=None):
+    rr = []
+    for tld in getAllCurrentTld():
+        rr.append(f"meta.{tld}")
+        rr.append(f"google.{tld}")
+
+    return rr
+
+
+def usage():
+    print(
+        """
+test.py
+    [ -v | --verbose ]
+        # set verbose to True, this will be forwarded to whois.query
+
+    [ -I | --IgnoreReturncode ]
+        # sets the IgnoreReturncode to True, this will be forwarded to whois.query
+
+    [ -a | --all]
+        # test all existing tld currently supported,
+
+"""
+    )
+
+
+def showFailures():
+    if len(Failures):
+        print("\n# ========================")
+        for i in sorted(Failures.keys()):
+            for j in sorted(Failures[i].keys()):
+                print(i, j, Failures[i][j])
+
+
+def main(argv):
+    global Verbose
+    global IgnoreReturncode
+    global PrintGetRawWhoisResult
+    global Ruleset
+
+    try:
+        opts, args = getopt.getopt(
+            argv,
+            "pvI",
+            [
+                "print",
+                "verbose",
+                "IgnoreReturncode",
+            ],
+        )
+    except getopt.GetoptError:
+        usage()
+        sys.exit(2)
+
+    for opt, arg in opts:
+        if opt == "-h":
+            usage()
+            sys.exit(0)
+
+        if opt in ("-v", "--verbose"):
+            Verbose = True
+
+        if opt in ("-p", "--print"):
+            PrintGetRawWhoisResult = True
+
+    print("## ===== TEST CURRENT TLD's")
+    allMetaTld = makeMetaAllCurrentTld()
+    testDomains(allMetaTld)
+    showFailures()
+    return
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -22,7 +22,7 @@ com = {
     "creation_date": r"Creation Date:\s?(.+)",
     "expiration_date": r"Registry Expiry Date:\s?(.+)",
     "updated_date": r"Updated Date:\s?(.+)",
-    "name_servers": r"Name Server:\s*(.+)\s*",
+    "name_servers": r"Name Server:\s*(.+)\s*",  # host -t ns <domain> often has more nameservers then the output of whois
     "status": r"Status:\s?(.+)",
     # the trailing domain must have minimal 2 parts firstname.lastname@fld.tld
     # it may actually have more then 4 levels
@@ -47,13 +47,13 @@ co_uk = {
     "extend": "uk",
     "domain_name": r"Domain name:\s+(.+)",
     "registrar": r"Registrar:\s+(.+)",
-    "name_servers": r"Name servers:\s+(.+)\s+(.+)",
+    "name_servers": r"Name servers:(?:\n\s+(\S+))?(?:\n\s+(\S+))?(?:\n\s+(\S+))?(?:\n\s+(\S+))?\n\n",  # capture up to 4
     "status": r"Registration status:\s*(.+)",
     "creation_date": r"Registered on:(.+)",
     "expiration_date": r"Expiry date:(.+)",
     "updated_date": r"Last updated:(.+)",
     "owner": r"Domain Owner:\s+(.+)",
-    "registrant": r"Registered Contact:\s+(.+)",
+    "registrant": r"Registrant:\n\s+(.+)",  # example meta.co.uk has a registrar google.co.uk has not
 }
 
 # United Arab Emirates
@@ -136,7 +136,7 @@ ax = {
     "creation_date": r"created\.+:\s*(\S+)",
     "expiration_date": r"expires\.+:\s*(\S+)",
     "updated_date": r"modified\.+:\s?(\S+)",
-    "name_servers": r"nserver\.+:\s*(\S+)",
+    "name_servers": r"nserver\.+:\s*(\S+)",  # host -t ns gives back more then output of whois
     "status": r"status\.+:\s*(\S+)",
     "registrant": r"Holder\s+name\.+:\s*(.+)\r?\n",  # not always present see meta.ax and google.ax
     "registrant_country": r"country\.+:\s*(.+)\r?\n",  # not always present see meta.ax and google.ax
@@ -163,6 +163,7 @@ be = {
     "registrar": r"Company Name:\n?(.+)",
     "creation_date": r"Registered:\s*(.+)\n",
     "status": r"Status:\s?(.+)",
+    "name_servers": r"Nameservers:(?:\n[ \t]+(\S+))?(?:\n[ \t]+(\S+))?(?:\n[ \t]+(\S+))?(?:\n[ \t]+(\S+))?\n\n",  # fix missing and wrong output
 }
 
 biz = {
@@ -188,16 +189,16 @@ br = {
     "status": r"status:\s?(.+)",
 }
 
-by = {
+by = {  # fix multiple dns by removing test for \n at the beginning as it is not needed
     "extend": "com",
     "domain_name": r"Domain Name:\s*(.+)",
-    "registrar": r"\nRegistrar:\s*(.+)",
-    "registrant": r"\nOrg:\s*(.+)",
-    "registrant_country": r"\nCountry:\s*(.+)",
-    "creation_date": r"\nCreation Date:\s*(.+)",
-    "expiration_date": r"\nExpiration Date:\s*(.+)",
-    "updated_date": r"\nUpdated Date:\s*(.+)",
-    "name_servers": r"\nName Server:\s*(.+)",
+    "registrar": r"Registrar:\s*(.+)",
+    "registrant": r"Org:\s*(.+)",
+    "registrant_country": r"Country:\s*(.+)",
+    "creation_date": r"Creation Date:\s*(.+)",
+    "expiration_date": r"Expiration Date:\s*(.+)",
+    "updated_date": r"Updated Date:\s*(.+)",
+    "name_servers": r"Name Server:\s+(\S+)\n",
 }
 
 # Brittany (French Territory)
@@ -334,7 +335,7 @@ cz = {
     "creation_date": r"registered:\s?(.+)",
     "expiration_date": r"expire:\s?(.+)",
     "updated_date": r"changed:\s?(.+)",
-    "name_servers": r"nserver:\s*(.+) ",
+    "name_servers": r"nserver:\s+(\S+)",
     "status": r"status:\s*(.+)",
 }
 
@@ -621,7 +622,8 @@ kg = {
     "creation_date": r"Record created:\s+(.+)",
     "updated_date": r"Record last updated on:\s+(.+)",
     # name servers have trailing whitespace
-    "name_servers": r"Name servers in the listed order:\n\n(?:(\S+)[ \t]*\n)(?:(\S+)[ \t]*\n)?",
+    "name_servers": r"Name servers in the listed order:\n\n(?:(\S+)[ \t]*\S*\n)(?:(\S+)[ \t]*\S*\n)?(?:(\S+)[ \t]*\S*\n)?\n",
+    # nameservers can have trailing ip (e.g. google.kg)
     "status": r"Domain\s+\S+\s+\((\S+)\)",
 }
 
@@ -639,6 +641,7 @@ kr = {
     "expiration_date": r"Expiration Date\s*:\s?(.+)",
     "updated_date": r"Last Updated Date\s*:\s?(.+)",
     "status": r"status\s*:\s?(.+)",
+    "name_servers": r"Host Name\s+:\s+(\S+)\n",
 }
 
 kz = {
@@ -649,8 +652,8 @@ kz = {
     "expiration_date": None,
     "creation_date": r"Domain created:\s(.+)",
     "updated_date": r"Last modified :\s(.+)",
-    "name_servers": r"server.*:\s(.+)",
-    "status": r"Domain status :\s?(.+)",
+    "name_servers": r"ary server\.+:\s+(\S+)",
+    "status": r"Domain status :(?:\s+([^\n]+)\n)",
 }
 
 link = {
@@ -849,7 +852,8 @@ pl = {
     "creation_date": r"\ncreated:\s*(.+)\n",
     "updated_date": r"\nlast modified:\s*(.+)\n",
     "expiration_date": r"\noption expiration date:\s*(.+)\n",
-    "name_servers": r"\nnameservers:(?:\s*(\S+)[ \t\r]*\n)(?:\s*(\S+)[ \t\r]*\n)?(?:\s*(\S+)[ \t\r]*\n)?",
+    # ns: match up to 4
+    "name_servers": r"nameservers:(?:\s+(\S+)[^\n]*\n)(?:\s+(\S+)[^\n]*\n)?(?:\s+(\S+)[^\n]*\n)?(?:\s+(\S+)[^\n]*\n)?",
     "status": r"\nStatus:\n\s*(.+)",
 }
 
@@ -961,7 +965,7 @@ com_sg = {
     "updated_date": r"Modified Date:\s?(.+)",
     # fix needed after strip(\r) in _2_parse.py in version 0.19
     # "name_servers": r"Name Servers:\r\n(?:\s*(\S+)[ \t\r]*\n)(?:\s*(\S+)[ \t\r]*\n)?(?:\s*(\S+)[ \t\r]*\n)?",
-    "name_servers": r"Name Servers:(?:\s+(\S+))(?:\s+(\S+))?(?:\s+([\.\w]+)\s+)?",
+    "name_servers": r"Name Servers:(?:\s+(\S+))(?:\s+(\S+))?(?:\s+(\S+))?(?:\s+([\.\w]+)\s+)?",
     # this seems ok for 2 and 3 ns and does not catch the dnssec: line
     "status": r"Domain Status:\s*(.*)\r?\n",
     # "emails": r"(\S+@\S+)",
@@ -1115,6 +1119,8 @@ uz = {
     "expiration_date": r"Expiration Date:\s?(.+)",
     "updated_date": r"Updated Date:\s?(.+)",
     "status": r"Status:\s?(.+)",
+    "name_servers": r"Domain servers in listed order:(?:\n\s+(\S+))(?:\n\s+(\S+))?(?:\n\s+(\S+))?(?:\n\s+(\S+))?\n\n",
+    # sometimes 'not.defined is returned as a nameserver (e.g. google.uz)
 }
 
 vip = {
@@ -1502,7 +1508,7 @@ ac = {
     "domain_name": r"Domain Name:\s+(.+)",
     "registrar": r"Registrar:\s+(.+)",
     "status": r"Domain Status:\s(.+)",
-    "name_servers": r"Name Server:\s+(.+)",
+    "name_servers": r"Name Server:\s+(\S+)",
     "registrant_country": r"Registrant Country:\s*(.*)\r?\n",
     "updated_date": r"Updated Date:\s+(.+)",
     "creation_date": r"Creation Date:\s+(.+)",
@@ -1514,7 +1520,7 @@ ae = {
     "domain_name": r"Domain Name:\s+(.+)",
     "registrar": r"Registrar Name:\s+(.+)",
     "status": r"Status:\s(.+)",
-    "name_servers": r"Name Server:\s+(.+)",
+    "name_servers": r"Name Server:\s+(\S+)",  # host -t ns gives back more, but whois output only has 2
     "registrant_country": None,
     "creation_date": None,
     "expiration_date": None,
@@ -1572,6 +1578,7 @@ bj = {
     "expiration_date": r"Registry Expiry Date:\s?(.+)",
     "updated_date": r"Updated Date:\s?(.+)",
     "status": r"Status:\s?(.+)",
+    "name_servers": r"Name Server:\s+(\S+)\n",
 }
 
 buzz = {
@@ -1641,7 +1648,7 @@ ly = {
 }
 
 com_ly = {
-    "extend": "ly",
+    "extend": "ly",  # host -t ns <domain> often has more nameservers then output of whois
 }
 
 ma = {
@@ -1721,7 +1728,8 @@ sg = {
     "updated_date": r"\s+Modified Date:\s+(.+)",
     "status": r"\s+Domain Status:\s(.+)",
     "registrant_country": None,
-    "name_servers": r"Name Servers:\s+(\S+)[ \t]*\r?\n\s+(\S+)[ \t]*\r?\n\s+(\S+)",
+    "name_servers": r"Name Servers:(?:\n[ \t]+(\S+)[^\n]*)(?:\n[ \t]+(\S+)[^\n]*)?(?:\n[ \t]+(\S+)[^\n]*)?(?:\n[ \t]+(\S+)[^\n]*)?",
+    # make sure the dnssec is not matched
 }
 
 srl = {
@@ -1807,7 +1815,7 @@ bo = {
     "extend": None,
     "registrar": None,
     "status": None,
-    "name_servers": None,
+    "name_servers": None,  # bo has no nameservers, use host -t ns <domain>
     "updated_date": None,
 }
 
@@ -1965,7 +1973,7 @@ gg = {
     "domain_name": r"Domain:\s*\n\s+(.+)",
     "status": r"Domain Status:\s*\n\s+(.+)",
     "registrar": r"Registrar:\s*\n\s+(.+)",
-    "name_servers": r"Name servers:\s*\r?\n(?:\s+(\S+)\r?\n)(?:\s+(\S+)\r?\n)?(?:\s+(\S+)\r?\n)?",
+    "name_servers": r"Name servers:(?:\n\s+(\S+))?(?:\n\s+(\S+))?(?:\n\s+(\S+))?(?:\n\s+(\S+))?\n",
     "creation_date": r"Relevant dates:\s*\n\s+Registered on(.+)",
     "expiration_date": None,
     "updated_date": None,


### PR DESCRIPTION
the output of host -t ns <domain> gives a list of nameservers, if the number of nameservers from dns is different from whois the test program test3.py writes to output so we can see what we possibly have to fix

many domains actually have more nameservers in dns then in whois but for a few we found some fixes in the regex