### PR TITLE
Add an opportunity to specify max cache age

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ Raise an issue https://github.com/DannyCork/python-whois/issues/new
  * add support for returning the raw data from the whois command: flag include_raw_whois_text
  * add support for handling unsupported domains via whois raw text only: flag return_raw_text_for_unsupported_tld
 
+2023-01-18: sorrowless
+ * add an opportunity to specify maximum cache age
+
 ## Support
  * Python 3.x is supported.
  * Python 2.x IS NOT supported.

--- a/makeTestdataAll.sh
+++ b/makeTestdataAll.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 TMPDIR="./tmp" # the default work directory is a local tmp (exclude by .gitignore )
 

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/bash
+#! /usr/bin/env bash
 
 # signal whois module that we are testing, this reads data from testdata/<domain>/in
 prepPath()
@@ -22,7 +22,7 @@ testOneDomain()
     echo "testing: $domain"
     ./test2.py -d "$domain" >"$TestDataDir/$domain/test.out"
 
-    diff "$TestDataDir/$domain/output" "$TestDataDir/$domain/test.out" | 
+    diff "$TestDataDir/$domain/output" "$TestDataDir/$domain/test.out" |
     tee "$TestDataDir/$domain/diff.out"
 }
 

--- a/whois/_1_query.py
+++ b/whois/_1_query.py
@@ -41,6 +41,7 @@ def do_query(
     dl: List[str],
     force: bool = False,
     cache_file: Optional[str] = None,
+    cache_age: int = CACHE_MAX_AGE,
     slow_down: int = 0,
     ignore_returncode: bool = False,
     server: Optional[str] = None,
@@ -53,7 +54,7 @@ def do_query(
 
     # actually also whois uses cache, so if you really dont want to use cache
     # you should also pass the --force-lookup flag (on linux)
-    if force or k not in CACHE or CACHE[k][0] < time.time() - CACHE_MAX_AGE:
+    if force or k not in CACHE or CACHE[k][0] < time.time() - cache_age:
         # slow down before so we can force individual domains at a slower tempo
         if slow_down:
             time.sleep(slow_down)

--- a/whois/__init__.py
+++ b/whois/__init__.py
@@ -305,6 +305,7 @@ def query(
     domain: str,
     force: bool = False,
     cache_file: Optional[str] = None,
+    cache_age: int = 60 * 60 * 48,
     slow_down: int = 0,
     ignore_returncode: bool = False,
     server: Optional[str] = None,
@@ -317,6 +318,7 @@ def query(
     """
     force=True          Don't use cache.
     cache_file=<path>   Use file to store cache not only memory.
+    cache_age=172800    Cache expiration time for given domain, in seconds
     slow_down=0         Time [s] it will wait after you query WHOIS database.
                         This is useful when there is a limit to the number of requests at a time.
     server:             if set use the whois server explicitly for making the query:
@@ -368,6 +370,7 @@ def query(
             dl=dl,
             force=force,
             cache_file=cache_file,
+            cache_age=cache_age,
             slow_down=slow_down,
             ignore_returncode=ignore_returncode,
             server=server,


### PR DESCRIPTION
If one have a case to use this library in an external tooling (e.g. monitoring solutions), it would be nice to allow changing maximum cache age. Such an option will allow to not reimplement own caches solution in such an external tooling and also reduce default 2 days cache age to provide changed domain info faster.

To do this, introduce additional option `cache_age` in do_query function.