### PR TITLE
add Malformed request to valid None return so that we retry one level up

### DIFF
--- a/whois/_2_parse.py
+++ b/whois/_2_parse.py
@@ -118,6 +118,16 @@ def handleShortResponse(
         d = ".".join(dl)
         print(f"line count < 5:: {tld} {d} {whois_str}", file=sys.stderr)
 
+    # TODO: some short responses are actually valid:
+    # lookfor Domain: and Status but all other fields are missing so the regexec could fail
+    # this domain is taken already or reserved
+
+    # whois syswow.64-b.it
+    # [Querying whois.nic.it]
+    # [whois.nic.it]
+    # Domain:             syswow.64-b.it
+    # Status:             UNASSIGNABLE
+
     s = whois_str.strip().lower()
 
     # NOTE: from here s is lowercase only

--- a/whois/_2_parse.py
+++ b/whois/_2_parse.py
@@ -134,6 +134,7 @@ def handleShortResponse(
         "status: available",
         "no whois server is known for this kind of object",
         "nameserver not found",
+        "malformed request", # this means this domain is not in whois as it is on top of a registered domain
     ]
 
     for i in noneStrings:

--- a/whois/_2_parse.py
+++ b/whois/_2_parse.py
@@ -134,7 +134,7 @@ def handleShortResponse(
         "status: available",
         "no whois server is known for this kind of object",
         "nameserver not found",
-        "malformed request", # this means this domain is not in whois as it is on top of a registered domain
+        "malformed request",  # this means this domain is not in whois as it is on top of a registered domain
     ]
 
     for i in noneStrings:


### PR DESCRIPTION
example is meta.firewall.org fails with Malformed request 
but firewall.org is the valid registered domain 