### PR TITLE
Added `timeout` parameter to limit the maximum wait time when running the whois CLI

### DIFF
--- a/whois/_1_query.py
+++ b/whois/_1_query.py
@@ -182,6 +182,9 @@ def _do_whois_query(
     try:
         r = p.communicate(timeout=timeout)[0].decode(errors="ignore")
     except subprocess.TimeoutExpired:
+        # Kill the child process & flush any output buffers
+        p.kill()
+        p.communicate()
         raise WhoisCommandTimeout()
 
     if verbose:

--- a/whois/__init__.py
+++ b/whois/__init__.py
@@ -218,6 +218,7 @@ def query(
     internationalized: bool = False,
     include_raw_whois_text: bool = False,
     return_raw_text_for_unsupported_tld: bool = False,
+    timeout: float = None,
 ) -> Optional[Domain]:
     """
     force=True          Don't use cache.
@@ -236,6 +237,8 @@ def query(
                         if reqested the full response is also returned.
     return_raw_text_for_unsupported_tld:
                         if the tld is unsupported, just try it anyway but return only the raw text.
+    timeout:
+                        timeout in seconds for the whois command to return a result.
     """
     global LastWhois
     LastWhois["Try"] = []  # init on start of query
@@ -281,6 +284,7 @@ def query(
             ignore_returncode=ignore_returncode,
             server=server,
             verbose=verbose,
+            timeout=timeout,
         )
         tryMe = {
             "Domain": ".".join(dl),

--- a/whois/exceptions.py
+++ b/whois/exceptions.py
@@ -23,3 +23,7 @@ class WhoisPrivateRegistry(Exception):
     # almost no info is returned or there is no cli whois server at all:
     # see: https://www.iana.org/domains/root/db/<tld>.html
     pass
+
+
+class WhoisCommandTimeout(Exception):
+    pass


### PR DESCRIPTION
Note the default timeout of the whois CLI is 61 seconds, which is too long for many applications.