### PR TITLE
testing the new timeout

### DIFF
--- a/reformat-code.sh
+++ b/reformat-code.sh
@@ -19,8 +19,7 @@ main()
 {
     ls *.py >/dev/null 2>/dev/null && doIt
     # ./test.py
-    mypy whois
-    mypy --install-types --non-interactive --namespace-packages whois
+    mypy --implicit-optional --install-types --non-interactive --namespace-packages whois
 }
 
 main

--- a/test2.py
+++ b/test2.py
@@ -176,12 +176,15 @@ def xType(x):
 def testItem(d: str, printgetRawWhoisResult: bool = False):
     global PrintGetRawWhoisResult
 
+    timout=30 # seconds
+
     w = whois.query(
         d,
         ignore_returncode=IgnoreReturncode,
         verbose=Verbose,
         internationalized=True,
         include_raw_whois_text=PrintGetRawWhoisResult,
+        timeout=timout,
     )
 
     if w is None:
@@ -250,6 +253,8 @@ def testDomains(aList):
             errorItem(d, e, what="WhoisQuotaExceeded")
         except whois.WhoisPrivateRegistry as e:
             errorItem(d, e, what="WhoisPrivateRegistry")
+        except whois.WhoisCommandTimeout as e:
+            errorItem(d, e, what="WhoisCommandTimeout")
         # except Exception as e:
         #    errorItem(d, e, what="Generic")
 

--- a/test2.py
+++ b/test2.py
@@ -176,7 +176,7 @@ def xType(x):
 def testItem(d: str, printgetRawWhoisResult: bool = False):
     global PrintGetRawWhoisResult
 
-    timout=30 # seconds
+    timout = 30  # seconds
 
     w = whois.query(
         d,

--- a/whois/__init__.py
+++ b/whois/__init__.py
@@ -32,6 +32,7 @@ from .exceptions import (
     WhoisCommandFailed,
     WhoisPrivateRegistry,
     WhoisQuotaExceeded,
+    WhoisCommandTimeout,
 )
 
 """


### PR DESCRIPTION
discovered one missing exception on import, test runs ok now

to run a test on all known tld's
./test2.py -a 2>2 | tee 1 

has 30 seconds timeout now

file 2 (the stderr output) should remain empty and all exceptions are reported at the end of the run in file 1

WhoisCommandTimeout meta.com.au 
WhoisCommandTimeout meta.eus 
WhoisCommandTimeout meta.pt 
