### PR TITLE
fix .tv whois server

### DIFF
--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -1037,6 +1037,7 @@ ZZ["trade"] = {
 
 ZZ["tv"] = {
     "extend": "com",
+    "_server": "whois.nic.tv",
     "domain_name": r"Domain Name:\s?(.+)",
     "registrar": r"Registrar:\s*(.+)",
     "creation_date": r"Creation Date:\s?(.+)",


### PR DESCRIPTION
```
>>> import whois
>>> whois.query("crypto.tv").__dict__
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'NoneType' object has no attribute '__dict__'
```