### PR TITLE
fix connect: Connection refused

### DIFF
--- a/whois/_1_query.py
+++ b/whois/_1_query.py
@@ -194,6 +194,9 @@ def _do_whois_query(
         # network error, "fgets: Connection reset by peer" fix, ignore 
         if "fgets: Connection reset by peer" in r:
             return r.replace("fgets: Connection reset by peer", "")
+        # connect: Connection refused
+        elif "connect: Connection refused" in r:
+            return r.replace("connect: Connection refused", "")
 
         raise WhoisCommandFailed(r)
 


### PR DESCRIPTION
whois shell error ignore.


```
>>> import whois
>>> whois.query("520gpt.com")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ubuntu/python-whois/whois/__init__.py", line 279, in query
    whois_str = do_query(
  File "/home/ubuntu/python-whois/whois/_1_query.py", line 71, in do_query
    _do_whois_query(
  File "/home/ubuntu/python-whois/whois/_1_query.py", line 198, in _do_whois_query
    raise WhoisCommandFailed(r)
whois.exceptions.WhoisCommandFailed: connect: Connection refused
   Domain Name: 520GPT.COM
   Registry Domain ID: 2756476274_DOMAIN_COM-VRSN
   Registrar WHOIS Server: whois.gname.com
   Registrar URL: http://www.gname.com
   Updated Date: 2023-02-06T06:17:39Z
```