### PR TITLE
fix test2.py; add rw second levels

### DIFF
--- a/test2.py
+++ b/test2.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python3
 
-from whoisdomain.main import main
+from whois.main import main
 
 main()

--- a/whois/tld_regexpr.py
+++ b/whois/tld_regexpr.py
@@ -1175,10 +1175,18 @@ ZZ["gy"] = {"extend": "com"}
 
 # Multiple initialization
 ZZ["ca"] = {"extend": "bank"}
-ZZ["rw"] = {
-    "extend": "com",
-    "_server": "whois.ricta.org.rw"
-}
+
+# Rwanda: https://en.wikipedia.org/wiki/.rw
+ZZ["rw"] = {"extend": "com", "_server": "whois.ricta.org.rw"}
+ZZ[".co.rw"] = {"extend": "rw"}
+ZZ[".org.rw"] = {"extend": "rw"}
+ZZ[".net.rw"] = {"extend": "rw"}
+ZZ[".ac.rw"] = {"extend": "rw"}
+ZZ[".gov.rw"] = {"extend": "rw"}
+ZZ[".mil.rw"] = {"extend": "rw"}
+ZZ[".coop.rw"] = {"extend": "rw"}
+# ZZ[".ltd.rw"] = {"extend": "rw"} # unclear, no longer in https://publicsuffix.org/list/public_suffix_list.dat 2023-06-27 mboot
+
 ZZ["mu"] = {"extend": "bank"}
 ZZ["mu"] = {"extend": "bank"}
 


### PR DESCRIPTION
# Rwanda: https://en.wikipedia.org/wiki/.rw
ZZ["rw"] = {"extend": "com", "_server": "whois.ricta.org.rw"}
ZZ[".co.rw"] = {"extend": "rw"}
ZZ[".org.rw"] = {"extend": "rw"}
ZZ[".net.rw"] = {"extend": "rw"}
ZZ[".ac.rw"] = {"extend": "rw"}
ZZ[".gov.rw"] = {"extend": "rw"}
ZZ[".mil.rw"] = {"extend": "rw"}
ZZ[".coop.rw"] = {"extend": "rw"}
# ZZ[".ltd.rw"] = {"extend": "rw"} # unclear, no longer in https://publicsuffix.org/list/public_suffix_list.dat 2023-06-27 mboot